### PR TITLE
Update wechatpay-apiv3.postman_collection.json

### DIFF
--- a/wechatpay-apiv3.postman_collection.json
+++ b/wechatpay-apiv3.postman_collection.json
@@ -4408,7 +4408,7 @@
 						{
 							"name": "条件查询批次列表",
 							"request": {
-								"method": "POST",
+								"method": "GET",
 								"header": [],
 								"url": {
 									"raw": "{{server_url}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
@@ -4459,7 +4459,7 @@
 								{
 									"name": "200_OK",
 									"originalRequest": {
-										"method": "POST",
+										"method": "GET",
 										"header": [],
 										"url": {
 											"raw": "{{server_url}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
@@ -6794,7 +6794,7 @@
 						{
 							"name": "终止活动",
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [],
 								"url": {
 									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要终止的支付有礼活动id}}/terminate",
@@ -6815,7 +6815,7 @@
 								{
 									"name": "200_OK",
 									"originalRequest": {
-										"method": "GET",
+										"method": "POST",
 										"header": [],
 										"url": {
 											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要终止的支付有礼活动id}}/terminate",
@@ -7809,7 +7809,14 @@
 							"name": "请求分账",
 							"request": {
 								"method": "POST",
-								"header": [],
+								"header": [
+									{
+										"key": "Wechatpay-Serial",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
 								"body": {
 									"mode": "raw",
 									"raw": "{\n  \"appid\": \"{{appid}}\",///商户号绑定的APPID\n  \"transaction_id\": \"4208450740201411110007820472\",///要分账的微信支付订单号\n  \"out_order_no\": \"P2022111111111100011\",///商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@\n  \"receivers\": [\n    {\n      \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n      \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n      \"amount\": 888,///要分出给接收方的分账金额，单位为“分”，只能为整数，不能超过原订单实际支付金额及最大分账比例金额\n      \"description\": \"分给商户A\"///分账的原因描述，分账账单中需要体现\n    }\n  ],\n  \"unfreeze_unsplit\": true ///1、如果为true，该笔订单剩余未分账的金额会解冻回分账方商户； 2、如果为false，该笔订单剩余未分账的金额不会解冻回分账方商户，可以对该笔订单再次进行分账。\n}",

--- a/wechatpay-apiv3.postman_collection.json
+++ b/wechatpay-apiv3.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "85f478d8-2596-420a-9f21-53376fc6ad0a",
+		"_postman_id": "404c1bb2-b585-42d0-ab2b-07d2ab60630c",
 		"name": "微信支付 APIv3",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "3391715"
+		"_exporter_id": "15520576"
 	},
 	"item": [
 		{
@@ -15,14 +15,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "https://api.mch.weixin.qq.com/v3/certificates",
-							"protocol": "https",
+							"raw": "{{endpoint}}/v3/certificates",
 							"host": [
-								"api",
-								"mch",
-								"weixin",
-								"qq",
-								"com"
+								"{{endpoint}}"
 							],
 							"path": [
 								"v3",
@@ -32,7 +27,7 @@
 					},
 					"response": [
 						{
-							"name": "获取微信支付平台证书列表",
+							"name": "200_OK",
 							"originalRequest": {
 								"method": "GET",
 								"header": [
@@ -44,14 +39,9 @@
 									}
 								],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/certificates",
-									"protocol": "https",
+									"raw": "{{endpoint}}/v3/certificates",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{endpoint}}"
 									],
 									"path": [
 										"v3",
@@ -132,56 +122,19 @@
 			]
 		},
 		{
-			"name": "JSAPI支付",
+			"name": "基础支付",
 			"item": [
 				{
-					"name": "JSAPI下单",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"mchid\": \"190000****\",\n\t\"out_trade_no\": \"20220907-test-***\",\n\t\"appid\": \"wxa9d9651ae82ec4b9\",\n\t\"description\": \"Image形象店-深圳腾大-QQ公仔\",\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\",\n\t\"amount\": {\n\t\t\"total\": 1,\n\t\t\"currency\": \"CNY\"\n\t},\n\t\"payer\": {\n\t\t\"openid\": \"oLTPCuN5a-nBD4rAL_fa0o8p****\"\n\t}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi",
-							"protocol": "https",
-							"host": [
-								"api",
-								"mch",
-								"weixin",
-								"qq",
-								"com"
-							],
-							"path": [
-								"v3",
-								"pay",
-								"transactions",
-								"jsapi"
-							]
-						}
-					},
-					"response": [
+					"name": "JSAPI支付",
+					"item": [
 						{
-							"name": "200_OK",
-							"originalRequest": {
+							"name": "JSAPI下单",
+							"request": {
 								"method": "POST",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "{{auth}}",
-										"description": "客户端的身份认证信息",
-										"type": "text"
-									}
-								],
+								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"mchid\": \"190000****\",\n\t\"out_trade_no\": \"20220907-test-***\",\n\t\"appid\": \"wxa9d9651ae82ec4b9\",\n\t\"description\": \"Image形象店-深圳腾大-QQ公仔\",\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\",\n\t\"amount\": {\n\t\t\"total\": 1,\n\t\t\"currency\": \"CNY\"\n\t},\n\t\"payer\": {\n\t\t\"openid\": \"oLTPCuN5a-nBD4rAL_fa0o8p****\"\n\t}\n}",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_1.shtml\n   接口说明：商户系统先调用该接口在微信支付服务后台生成预支付交易单，返回正确的预支付交易会话标识后再按Native、JSAPI、APP等不同场景生成交易串调起支付。 */\n{\n\t\"appid\": \"{{appid}}\", ///请求基础下单接口时请注意APPID的应用属性，例如公众号场景下，需使用应用属性为公众号的服务号APPID\n    \"mchid\": \"{{mchid}}\", ///商户号,要与请求头保持一致\n    \"description\": \"Image形象店-深圳腾大-QQ公仔\", ///商品描述\n\t\"out_trade_no\": \"Tencentwechatpay0000001\", ///户系统内部订单号，只能是数字、大小写字母_-*且在同一个商户号下唯一\n\t\"time_expire\":\"2022-11-11T23:59:59+08:00\",\n    /*订单失效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。 */\n\t\"attach\":\"附加数据\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\", \n    /* 异步接收微信支付结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 公网域名必须为https，如果是走专线接入，使用专线NAT IP或者私有回调域名可使用http */\n    \"support_fapiao\":false, ///传入true时，支付成功消息和支付详情页将出现开票入口。需要在微信支付商户平台或微信公众平台开通电子发票功能，传此字段才可生效。\n\t\"amount\": {\n\t\t\"total\": 50, ///订单总金额，单位为“分”\n\t\t\"currency\": \"CNY\" /// CNY：人民币，境内商户号仅支持人民币。\n\t},\n\t\"payer\": {\n\t\t\"openid\": \"{{openid}}\" ///用户在直连商户appid下的唯一标识，不可混用\n\t},\n    \"settle_info\":{\n        \"profit_sharing\":false ///是否指定分账\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -189,7 +142,516 @@
 									}
 								},
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi",
+									"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"jsapi"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"jsapi"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"prepay_id\": \"wx042120326484513d5ff2fe243d766e0000\"\n    /* 预支付交易会话标识。用于后续接口调用中使用，该值有效期为2小时 */\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_商户订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{将此处替换为要查询的商户订单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{将此处替换为要查询的商户订单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_微信支付订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"id",
+										"{{将此处替换为要查询的微信支付单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"id",
+												"{{将此处替换为要查询的微信支付单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "关闭订单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_3.shtml\n   接口说明：以下情况需要调用关单接口：\n1、商户订单支付失败需要生成新单号重新发起支付，要对原订单号调用关单，避免重复支付；\n2、系统下单后，用户支付超时，系统退出不再受理，避免用户继续，请调用关单接口。\n注意：\n• 关单没有时间限制，建议在订单生成后间隔几分钟（最短5分钟）再调用关单接口，避免出现订单状态同步不及时导致关单失败。 */\n\n{\n\t\"mchid\": \"{{mchid}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{此处替换为要关闭的商家订单号}}",
+										"close"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{此处替换为要关闭的商家订单号}}",
+												"close"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "申请退款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_9.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"transaction_id\": \"1217752501201407033233368018\",\n  \"out_refund_no\": \"1217752501201407033233368018\",\n  \"reason\": \"商品已售完\",\n  \"notify_url\": \"https://weixin.qq.com\",\n  \"funds_account\": \"AVAILABLE\",\n  \"amount\": {\n    \"refund\": 888,\n    \"from\": [\n      {\n        \"account\": \"AVAILABLE\",\n        \"amount\": 444\n      }\n    ],\n    \"total\": 888,\n    \"currency\": \"CNY\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询单笔退款",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds",
+										"{{此处替换为要查询的商户自己生成的退款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds",
+												"{{此处替换为要查询的商户自己生成的退款单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "申请交易账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"tradebill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										},
+										{
+											"key": "bill_type",
+											"value": "ALL",
+											"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"tradebill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												},
+												{
+													"key": "bill_type",
+													"value": "ALL",
+													"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\n    \"hash_type\": \"SHA1\", ///哈希类型\t\n    \"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\t\n}"
+								}
+							]
+						},
+						{
+							"name": "申请资金账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"fundflowbill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"fundflowbill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "下载账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"protocol": "https",
 									"host": [
 										"api",
@@ -200,83 +662,8132 @@
 									],
 									"path": [
 										"v3",
+										"billdownload",
+										"file"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"description": "通过申请账单接口获取到“download_url”，URL有效期30s"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"protocol": "https",
+											"host": [
+												"api",
+												"mch",
+												"weixin",
+												"qq",
+												"com"
+											],
+											"path": [
+												"v3",
+												"billdownload",
+												"file"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "交易时间,公众账号ID,商户号,设备号,微信订单号,商户订单号,用户标识,交易类型,交易状态,付款银行,货币种类,应结订单金额,代金券金额,微信退款单号,商户退款单号,退款金额,充值券退款金额,退款类型,退款状态,商品名称,商户数据包,手续费,费率,订单金额,申请退款金额,费率备注\n`2022-10-30 20:12:31,`wxdace645e0bc2cXXX,`1900006XXX,`,`4200000891202103228088184743,`Tencentwechatpay0000001,`obNGB5XGH29T8l1SzegeEZh1HHm0,`JSAPI,`SUCCESS,`OTHERS,`CNY,`50.00,`0.00,`0,`0,`0.00,`0.00,`,`,`汾酒53°;,`,`0.19000,`0.38%,`50.00,`0.00,`\n`2022-10-30 13:29:42,`wxdace645e0bc2cXXX,`1900006XXX,,`,`4200000891202103228088184741,`Tencentwechatpay0000002,`obNGB5Vefw_48hZPE27U33dA-tOk,`JSAPI,`SUCCESS,`OTHERS,`CNY,`135.00,`0.00,`0,`0,`0.00,`0.00,`,`,`泰谷;,`,`0.51000,`0.38%,`135.00,`0.00,`\n总交易单数,应结订单总金额,退款总金额,充值券退款总金额,手续费总金额,订单总金额,申请退款总金额\n`2,`185.00,`0.00,`0.00,`0.70000,`185.00,`0.00\n"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "APP支付",
+					"item": [
+						{
+							"name": "APP下单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_2_1.shtml\n   接口说明：商户系统先调用该接口在微信支付服务后台生成预支付交易单，返回正确的预支付交易会话标识后再按Native、JSAPI、APP等不同场景生成交易串调起支付。 */\n{\n\t\"appid\": \"{{appid}}\", ///请求基础下单接口时请注意APPID的应用属性，例如公众号场景下，需使用应用属性为公众号的服务号APPID\n    \"mchid\": \"{{mchid}}\", ///商户号,要与请求头保持一致\n    \"description\": \"Image形象店-深圳腾大-QQ公仔\", ///商品描述\n\t\"out_trade_no\": \"Tencentwechatpay0000001\", ///户系统内部订单号，只能是数字、大小写字母_-*且在同一个商户号下唯一\n\t\"time_expire\":\"2022-11-11T23:59:59+08:00\",\n    /*订单失效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。 */\n\t\"attach\":\"附加数据\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\", \n    /* 异步接收微信支付结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 公网域名必须为https，如果是走专线接入，使用专线NAT IP或者私有回调域名可使用http */\n    \"support_fapiao\":false, ///传入true时，支付成功消息和支付详情页将出现开票入口。需要在微信支付商户平台或微信公众平台开通电子发票功能，传此字段才可生效。\n\t\"amount\": {\n\t\t\"total\": 50, ///订单总金额，单位为“分”\n\t\t\"currency\": \"CNY\" /// CNY：人民币，境内商户号仅支持人民币。\n\t},\n    \"settle_info\":{\n        \"profit_sharing\":false ///是否指定分账\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/app",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"app"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{domain}}/v3/pay/transactions/app",
+											"host": [
+												"{{domain}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"app"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"prepay_id\": \"wx071900406588238ff38ea3608d8b360904\"\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_商户订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{将此处替换为要查询的商户订单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{将此处替换为要查询的商户订单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"APP\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_微信支付订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"id",
+										"{{将此处替换为要查询的微信支付单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"id",
+												"{{将此处替换为要查询的微信支付单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"APP\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "关闭订单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_2_3.shtml\n   接口说明：以下情况需要调用关单接口：\n1、商户订单支付失败需要生成新单号重新发起支付，要对原订单号调用关单，避免重复支付；\n2、系统下单后，用户支付超时，系统退出不再受理，避免用户继续，请调用关单接口。\n注意：\n• 关单没有时间限制，建议在订单生成后间隔几分钟（最短5分钟）再调用关单接口，避免出现订单状态同步不及时导致关单失败。 */\n\n{\n\t\"mchid\": \"{{mchid}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{此处替换为要关闭的商家订单号}}",
+										"close"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{domain}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的订单号}}/close",
+											"host": [
+												"{{domain}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{此处替换为要关闭的订单号}}",
+												"close"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "申请退款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_9.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"transaction_id\": \"1217752501201407033233368018\",\n  \"out_refund_no\": \"1217752501201407033233368018\",\n  \"reason\": \"商品已售完\",\n  \"notify_url\": \"https://weixin.qq.com\",\n  \"funds_account\": \"AVAILABLE\",\n  \"amount\": {\n    \"refund\": 888,\n    \"from\": [\n      {\n        \"account\": \"AVAILABLE\",\n        \"amount\": 444\n      }\n    ],\n    \"total\": 888,\n    \"currency\": \"CNY\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{domain}}/v3/refund/domestic/refunds",
+											"host": [
+												"{{domain}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询单笔退款",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds",
+										"{{此处替换为要查询的商户自己生成的退款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds",
+												"{{此处替换为要查询的商户自己生成的退款单号}}"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "申请交易账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"tradebill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										},
+										{
+											"key": "bill_type",
+											"value": "ALL",
+											"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{domain}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"host": [
+												"{{domain}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"tradebill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												},
+												{
+													"key": "bill_type",
+													"value": "ALL",
+													"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\n    \"hash_type\": \"SHA1\", ///哈希类型\t\n    \"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\t\n}"
+								}
+							]
+						},
+						{
+							"name": "申请资金账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"fundflowbill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"fundflowbill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2022-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "下载账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+									"protocol": "https",
+									"host": [
+										"api",
+										"mch",
+										"weixin",
+										"qq",
+										"com"
+									],
+									"path": [
+										"v3",
+										"billdownload",
+										"file"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"description": "通过申请账单接口获取到“download_url”，URL有效期30s"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"protocol": "https",
+											"host": [
+												"api",
+												"mch",
+												"weixin",
+												"qq",
+												"com"
+											],
+											"path": [
+												"v3",
+												"billdownload",
+												"file"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "交易时间,公众账号ID,商户号,设备号,微信订单号,商户订单号,用户标识,交易类型,交易状态,付款银行,货币种类,应结订单金额,代金券金额,微信退款单号,商户退款单号,退款金额,充值券退款金额,退款类型,退款状态,商品名称,商户数据包,手续费,费率,订单金额,申请退款金额,费率备注\n`2022-10-30 20:12:31,`wxdace645e0bc2cXXX,`1900006XXX,`,`4200000891202103228088184743,`Tencentwechatpay0000001,`obNGB5XGH29T8l1SzegeEZh1HHm0,`JSAPI,`SUCCESS,`OTHERS,`CNY,`50.00,`0.00,`0,`0,`0.00,`0.00,`,`,`汾酒53°;,`,`0.19000,`0.38%,`50.00,`0.00,`\n`2022-10-30 13:29:42,`wxdace645e0bc2cXXX,`1900006XXX,,`,`4200000891202103228088184741,`Tencentwechatpay0000002,`obNGB5Vefw_48hZPE27U33dA-tOk,`JSAPI,`SUCCESS,`OTHERS,`CNY,`135.00,`0.00,`0,`0,`0.00,`0.00,`,`,`泰谷;,`,`0.51000,`0.38%,`135.00,`0.00,`\n总交易单数,应结订单总金额,退款总金额,充值券退款总金额,手续费总金额,订单总金额,申请退款总金额\n`2,`185.00,`0.00,`0.00,`0.70000,`185.00,`0.00\n"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "H5支付",
+					"item": [
+						{
+							"name": "H5下单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_3_1.shtml\n   接口说明：商户系统先调用该接口在微信支付服务后台生成预支付交易单，返回正确的预支付交易会话标识后再按Native、JSAPI、APP等不同场景生成交易串调起支付。 */\n{\n\t\"appid\": \"{{appid}}\", ///请求基础下单接口时请注意APPID的应用属性，例如公众号场景下，需使用应用属性为公众号的服务号APPID\n    \"mchid\": \"{{mchid}}\", ///商户号,要与请求头保持一致\n    \"description\": \"Image形象店-深圳腾大-QQ公仔\", ///商品描述\n\t\"out_trade_no\": \"Tencentwechatpay0000001\", ///户系统内部订单号，只能是数字、大小写字母_-*且在同一个商户号下唯一\n\t\"time_expire\":\"2022-11-11T23:59:59+08:00\",\n    /*订单失效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。 */\n\t\"attach\":\"附加数据\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\", \n    /* 异步接收微信支付结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 公网域名必须为https，如果是走专线接入，使用专线NAT IP或者私有回调域名可使用http */\n    \"support_fapiao\":false, ///传入true时，支付成功消息和支付详情页将出现开票入口。需要在微信支付商户平台或微信公众平台开通电子发票功能，传此字段才可生效。\n\t\"amount\": {\n\t\t\"total\": 50, ///订单总金额，单位为“分”\n\t\t\"currency\": \"CNY\" /// CNY：人民币，境内商户号仅支持人民币。\n\t},\n    \"scene_info\": {\n\t\t\"payer_client_ip\": \"127.0.0.1\",///用户的客户端IP，支持IPv4和IPv6两种格式的IP地址\n\t\t\"h5_info\": {\n\t\t\t\"type\": \"Wap\"///场景类型,示例值：iOS, Android, Wap\n\t\t}\n\t},\n    \"settle_info\":{\n        \"profit_sharing\":false ///是否指定分账\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/h5",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"h5"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/h5",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"h5"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n\t\"h5_url\": \"https://wx.tenpay.com/cgi-bin/mmpayweb-bin/checkmweb?prepay_id=wx2916263004719461949c84457c735b0000&package=2150917749\"\n    ///支付跳转链接:  h5_url为拉起微信支付收银台的中间页面，可通过访问该url来拉起微信客户端，完成支付，h5_url的有效期为5分钟。\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_商户订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{将此处替换为要查询的商户订单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{将此处替换为要查询的商户订单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_微信支付订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"id",
+										"{{将此处替换为要查询的微信支付单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"id",
+												"{{将此处替换为要查询的微信支付单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "关闭订单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_3_3.shtml\n   接口说明：以下情况需要调用关单接口：\n1、商户订单支付失败需要生成新单号重新发起支付，要对原订单号调用关单，避免重复支付；\n2、系统下单后，用户支付超时，系统退出不再受理，避免用户继续，请调用关单接口。\n注意：\n• 关单没有时间限制，建议在订单生成后间隔几分钟（最短5分钟）再调用关单接口，避免出现订单状态同步不及时导致关单失败。 */\n\n{\n\t\"mchid\": \"{{mchid}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{此处替换为要关闭的商家订单号}}",
+										"close"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{此处替换为要关闭的商家订单号}}",
+												"close"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "申请退款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_3_9.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"transaction_id\": \"1217752501201407033233368018\",\n  \"out_refund_no\": \"1217752501201407033233368018\",\n  \"reason\": \"商品已售完\",\n  \"notify_url\": \"https://weixin.qq.com\",\n  \"funds_account\": \"AVAILABLE\",\n  \"amount\": {\n    \"refund\": 888,\n    \"from\": [\n      {\n        \"account\": \"AVAILABLE\",\n        \"amount\": 444\n      }\n    ],\n    \"total\": 888,\n    \"currency\": \"CNY\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询单笔退款",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds",
+										"{{此处替换为要查询的商户自己生成的退款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds",
+												"{{此处替换为要查询的商户自己生成的退款单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "申请交易账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"tradebill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										},
+										{
+											"key": "bill_type",
+											"value": "ALL",
+											"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"tradebill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												},
+												{
+													"key": "bill_type",
+													"value": "ALL",
+													"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\n    \"hash_type\": \"SHA1\", ///哈希类型\t\n    \"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\t\n}"
+								}
+							]
+						},
+						{
+							"name": "申请资金账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"fundflowbill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"fundflowbill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "下载账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+									"protocol": "https",
+									"host": [
+										"api",
+										"mch",
+										"weixin",
+										"qq",
+										"com"
+									],
+									"path": [
+										"v3",
+										"billdownload",
+										"file"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"description": "通过申请账单接口获取到“download_url”，URL有效期30s"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"protocol": "https",
+											"host": [
+												"api",
+												"mch",
+												"weixin",
+												"qq",
+												"com"
+											],
+											"path": [
+												"v3",
+												"billdownload",
+												"file"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "交易时间,公众账号ID,商户号,设备号,微信订单号,商户订单号,用户标识,交易类型,交易状态,付款银行,货币种类,应结订单金额,代金券金额,微信退款单号,商户退款单号,退款金额,充值券退款金额,退款类型,退款状态,商品名称,商户数据包,手续费,费率,订单金额,申请退款金额,费率备注\n`2022-10-30 20:12:31,`wxdace645e0bc2cXXX,`1900006XXX,`,`4200000891202103228088184743,`Tencentwechatpay0000001,`obNGB5XGH29T8l1SzegeEZh1HHm0,`JSAPI,`SUCCESS,`OTHERS,`CNY,`50.00,`0.00,`0,`0,`0.00,`0.00,`,`,`汾酒53°;,`,`0.19000,`0.38%,`50.00,`0.00,`\n`2022-10-30 13:29:42,`wxdace645e0bc2cXXX,`1900006XXX,,`,`4200000891202103228088184741,`Tencentwechatpay0000002,`obNGB5Vefw_48hZPE27U33dA-tOk,`JSAPI,`SUCCESS,`OTHERS,`CNY,`135.00,`0.00,`0,`0,`0.00,`0.00,`,`,`泰谷;,`,`0.51000,`0.38%,`135.00,`0.00,`\n总交易单数,应结订单总金额,退款总金额,充值券退款总金额,手续费总金额,订单总金额,申请退款总金额\n`2,`185.00,`0.00,`0.00,`0.70000,`185.00,`0.00\n"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Native支付",
+					"item": [
+						{
+							"name": "Native下单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_4_1.shtml\n   接口说明：商户系统先调用该接口在微信支付服务后台生成预支付交易单，返回正确的预支付交易会话标识后再按Native、JSAPI、APP等不同场景生成交易串调起支付。 */\n{\n\t\"appid\": \"{{appid}}\", ///请求基础下单接口时请注意APPID的应用属性，例如公众号场景下，需使用应用属性为公众号的服务号APPID\n    \"mchid\": \"{{mchid}}\", ///商户号,要与请求头保持一致\n    \"description\": \"Image形象店-深圳腾大-QQ公仔\", ///商品描述\n\t\"out_trade_no\": \"Tencentwechatpay0000001\", ///户系统内部订单号，只能是数字、大小写字母_-*且在同一个商户号下唯一\n\t\"time_expire\":\"2022-11-11T23:59:59+08:00\",\n    /*订单失效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。 */\n\t\"attach\":\"附加数据\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\", \n    /* 异步接收微信支付结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 公网域名必须为https，如果是走专线接入，使用专线NAT IP或者私有回调域名可使用http */\n    \"support_fapiao\":false, ///传入true时，支付成功消息和支付详情页将出现开票入口。需要在微信支付商户平台或微信公众平台开通电子发票功能，传此字段才可生效。\n\t\"amount\": {\n\t\t\"total\": 50, ///订单总金额，单位为“分”\n\t\t\"currency\": \"CNY\" /// CNY：人民币，境内商户号仅支持人民币。\n\t},\n    \"settle_info\":{\n        \"profit_sharing\":false ///是否指定分账\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/native",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"native"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/native",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"native"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n\t\"code_url\": \"weixin://wxpay/bizpayurl?pr=p4lpSuKzz\"\n    ///此URL用于生成支付二维码，然后提供给用户扫码支付。\n    ///注意：code_url并非固定值，使用时按照URL格式转成二维码即可。\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_商户订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{将此处替换为要查询的商户订单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{将此处替换为要查询的商户订单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_微信支付订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"id",
+										"{{将此处替换为要查询的微信支付单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"id",
+												"{{将此处替换为要查询的微信支付单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "关闭订单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_3.shtml\n   接口说明：以下情况需要调用关单接口：\n1、商户订单支付失败需要生成新单号重新发起支付，要对原订单号调用关单，避免重复支付；\n2、系统下单后，用户支付超时，系统退出不再受理，避免用户继续，请调用关单接口。\n注意：\n• 关单没有时间限制，建议在订单生成后间隔几分钟（最短5分钟）再调用关单接口，避免出现订单状态同步不及时导致关单失败。 */\n\n{\n\t\"mchid\": \"{{mchid}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{此处替换为要关闭的商家订单号}}",
+										"close"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{此处替换为要关闭的商家订单号}}",
+												"close"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "申请退款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_9.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"transaction_id\": \"1217752501201407033233368018\",\n  \"out_refund_no\": \"1217752501201407033233368018\",\n  \"reason\": \"商品已售完\",\n  \"notify_url\": \"https://weixin.qq.com\",\n  \"funds_account\": \"AVAILABLE\",\n  \"amount\": {\n    \"refund\": 888,\n    \"from\": [\n      {\n        \"account\": \"AVAILABLE\",\n        \"amount\": 444\n      }\n    ],\n    \"total\": 888,\n    \"currency\": \"CNY\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询单笔退款",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds",
+										"{{此处替换为要查询的商户自己生成的退款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds",
+												"{{此处替换为要查询的商户自己生成的退款单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "申请交易账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"tradebill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										},
+										{
+											"key": "bill_type",
+											"value": "ALL",
+											"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"tradebill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												},
+												{
+													"key": "bill_type",
+													"value": "ALL",
+													"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\n    \"hash_type\": \"SHA1\", ///哈希类型\t\n    \"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\t\n}"
+								}
+							]
+						},
+						{
+							"name": "申请资金账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"fundflowbill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"fundflowbill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "下载账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+									"protocol": "https",
+									"host": [
+										"api",
+										"mch",
+										"weixin",
+										"qq",
+										"com"
+									],
+									"path": [
+										"v3",
+										"billdownload",
+										"file"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"description": "通过申请账单接口获取到“download_url”，URL有效期30s"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"protocol": "https",
+											"host": [
+												"api",
+												"mch",
+												"weixin",
+												"qq",
+												"com"
+											],
+											"path": [
+												"v3",
+												"billdownload",
+												"file"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "交易时间,公众账号ID,商户号,设备号,微信订单号,商户订单号,用户标识,交易类型,交易状态,付款银行,货币种类,应结订单金额,代金券金额,微信退款单号,商户退款单号,退款金额,充值券退款金额,退款类型,退款状态,商品名称,商户数据包,手续费,费率,订单金额,申请退款金额,费率备注\n`2022-10-30 20:12:31,`wxdace645e0bc2cXXX,`1900006XXX,`,`4200000891202103228088184743,`Tencentwechatpay0000001,`obNGB5XGH29T8l1SzegeEZh1HHm0,`JSAPI,`SUCCESS,`OTHERS,`CNY,`50.00,`0.00,`0,`0,`0.00,`0.00,`,`,`汾酒53°;,`,`0.19000,`0.38%,`50.00,`0.00,`\n`2022-10-30 13:29:42,`wxdace645e0bc2cXXX,`1900006XXX,,`,`4200000891202103228088184741,`Tencentwechatpay0000002,`obNGB5Vefw_48hZPE27U33dA-tOk,`JSAPI,`SUCCESS,`OTHERS,`CNY,`135.00,`0.00,`0,`0,`0.00,`0.00,`,`,`泰谷;,`,`0.51000,`0.38%,`135.00,`0.00,`\n总交易单数,应结订单总金额,退款总金额,充值券退款总金额,手续费总金额,订单总金额,申请退款总金额\n`2,`185.00,`0.00,`0.00,`0.70000,`185.00,`0.00\n"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "小程序支付",
+					"item": [
+						{
+							"name": "JSAPI下单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_5_1.shtml\n   接口说明：商户系统先调用该接口在微信支付服务后台生成预支付交易单，返回正确的预支付交易会话标识后再按Native、JSAPI、APP等不同场景生成交易串调起支付。 */\n{\n\t\"appid\": \"{{appid}}\", ///请求基础下单接口时请注意APPID的应用属性，例如公众号场景下，需使用应用属性为公众号的服务号APPID\n    \"mchid\": \"{{mchid}}\", ///商户号,要与请求头保持一致\n    \"description\": \"Image形象店-深圳腾大-QQ公仔\", ///商品描述\n\t\"out_trade_no\": \"Tencentwechatpay0000001\", ///户系统内部订单号，只能是数字、大小写字母_-*且在同一个商户号下唯一\n\t\"time_expire\":\"2022-11-11T23:59:59+08:00\",\n    /*订单失效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。 */\n\t\"attach\":\"附加数据\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n\t\"notify_url\": \"https://www.weixin.qq.com/wxpay/pay.php\", \n    /* 异步接收微信支付结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 公网域名必须为https，如果是走专线接入，使用专线NAT IP或者私有回调域名可使用http */\n    \"support_fapiao\":false, ///传入true时，支付成功消息和支付详情页将出现开票入口。需要在微信支付商户平台或微信公众平台开通电子发票功能，传此字段才可生效。\n\t\"amount\": {\n\t\t\"total\": 50, ///订单总金额，单位为“分”\n\t\t\"currency\": \"CNY\" /// CNY：人民币，境内商户号仅支持人民币。\n\t},\n\t\"payer\": {\n\t\t\"openid\": \"{{openid}}\" ///用户在直连商户appid下的唯一标识，不可混用\n\t},\n    \"settle_info\":{\n        \"profit_sharing\":false ///是否指定分账\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
 										"pay",
 										"transactions",
 										"jsapi"
 									]
 								}
 							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
+							"response": [
 								{
-									"key": "Server",
-									"value": "nginx"
-								},
-								{
-									"key": "Date",
-									"value": "Wed, 07 Sep 2022 11:00:40 GMT"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json; charset=utf-8"
-								},
-								{
-									"key": "Content-Length",
-									"value": "52"
-								},
-								{
-									"key": "Connection",
-									"value": "keep-alive"
-								},
-								{
-									"key": "Keep-Alive",
-									"value": "timeout=8"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-cache, must-revalidate"
-								},
-								{
-									"key": "X-Content-Type-Options",
-									"value": "nosniff"
-								},
-								{
-									"key": "Request-ID",
-									"value": "08D7F3E19806109F071889D2EAA306200028F98101-0"
-								},
-								{
-									"key": "Request-ID",
-									"value": "08D7F3E19806109F071889D2EAA306200028F98101-0"
-								},
-								{
-									"key": "Content-Language",
-									"value": "zh-CN"
-								},
-								{
-									"key": "Wechatpay-Nonce",
-									"value": "c7f41cadbae3a6027d88e46daaa005ae"
-								},
-								{
-									"key": "Wechatpay-Signature",
-									"value": "T8xSLB9POrdp4mdiqT2egIREwGPBZ41JeraJcT5eLMODPDyKzPeFWBH/5sAvFhhiwEq5L10F9qtodLVdx12N/P/VPKTqxYyTKmUgq/yOPngbLFsZPpcMXyPkNbWLNRpMaRhwGjuJ91fzylFh/6vX11i2bV0p3C9iG8Luh2viCYg0lWCUeC2pWXdY/U2fjGj95448nkzjIENwGGoZ2kgiUWbaKeXV1p/D6Agog4ma0etJCOnOfzWjZ5CLVUa7TmaEsGerE2Bs0xLe9osNYC6D2jrSqRPsXlnjFUgBrHJjvnFxtrQmnucsU3YzYO7ah4NV1j/+ZdoShTS7KPzk0nzWVg=="
-								},
-								{
-									"key": "Wechatpay-Timestamp",
-									"value": "1662548440"
-								},
-								{
-									"key": "Wechatpay-Serial",
-									"value": "19FBBF2A24A3F3C97F5925FA855A850D6E4624AF"
-								},
-								{
-									"key": "Wechatpay-Signature-Type",
-									"value": "WECHATPAY2-SHA256-RSA2048"
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"jsapi"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"prepay_id\": \"wx042120326484513d5ff2fe243d766e0000\"\n    /* 预支付交易会话标识。用于后续接口调用中使用，该值有效期为2小时 */\n}"
 								}
-							],
-							"cookie": [],
-							"body": "{\n    \"prepay_id\": \"wx071900406588238ff38ea3608d8b360904\"\n}"
+							]
+						},
+						{
+							"name": "查询订单_商户订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{将此处替换为要查询的商户订单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{将此处替换为要查询的商户订单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单_微信支付订单号查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"id",
+										"{{将此处替换为要查询的微信支付单号}}"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"id",
+												"{{将此处替换为要查询的微信支付单号}}"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"amount\": {\n\t\t\"currency\": \"CNY\",\n\t\t\"payer_currency\": \"CNY\",\n\t\t\"payer_total\": 50, ///用户支付金额，单位为分。（指使用优惠券的情况下，这里等于总金额-优惠券金额）\n\t\t\"total\": 50 ///订单总金额，单位为分\n\t},\n\t\"appid\": \"wxdace645e0bc2cXXX\", /// 下单所传appid\n\t\"attach\": \"\", ///附加数据\n\t\"bank_type\": \"OTHERS\",///银行类型，采用字符串类型的银行标识。银行标识请参考“https://pay.weixin.qq.com/wiki/doc/apiv3/terms_definition/chapter1_1_3.shtml#part-6”\n\t\"mchid\": \"1900006XXX\", ///微信支付商户号\n\t\"out_trade_no\": \"Tencentwechatpay0000001\",/// 商户系统内部订单号，在商户号下唯一\n\t\"payer\": {\n\t\t\"openid\": \"o4GgauJP_mgWEWictzA15WT15XXX\" ///支付用户标识，与APPID相对应且在APPID下唯一\n\t},\n\t\"promotion_detail\": [],///优惠功能，当订单有享受优惠时返回该字段。\n\t\"success_time\": \"2021-03-22T10:29:05+08:00\",\n\t\"trade_state\": \"SUCCESS\", /*交易状态，枚举值：SUCCESS：支付成功；REFUND：转入退款；NOTPAY：未支付；CLOSED：已关闭；REVOKED：已撤销（仅付款码支付会返回）；USERPAYING：用户支付中（仅付款码支付会返回）；PAYERROR：支付失败（仅付款码支付会返回） */\n\t\"trade_state_desc\": \"支付成功\",\n\t\"trade_type\": \"JSAPI\", ///交易类型\t枚举值：JSAPI：公众号支付；NATIVE：扫码支付；APP：APP支付；MICROPAY：付款码支付；MWEB：H5支付；FACEPAY：刷脸支付\n\t\"transaction_id\": \"4200000891202103228088184743\" ///微信支付系统生成的订单号\n}"
+								}
+							]
+						},
+						{
+							"name": "关闭订单",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_3.shtml\n   接口说明：以下情况需要调用关单接口：\n1、商户订单支付失败需要生成新单号重新发起支付，要对原订单号调用关单，避免重复支付；\n2、系统下单后，用户支付超时，系统退出不再受理，避免用户继续，请调用关单接口。\n注意：\n• 关单没有时间限制，建议在订单生成后间隔几分钟（最短5分钟）再调用关单接口，避免出现订单状态同步不及时导致关单失败。 */\n\n{\n\t\"mchid\": \"{{mchid}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"pay",
+										"transactions",
+										"out-trade-no",
+										"{{此处替换为要关闭的商家订单号}}",
+										"close"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"pay",
+												"transactions",
+												"out-trade-no",
+												"{{此处替换为要关闭的商家订单号}}",
+												"close"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "申请退款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_9.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"transaction_id\": \"1217752501201407033233368018\",\n  \"out_refund_no\": \"1217752501201407033233368018\",\n  \"reason\": \"商品已售完\",\n  \"notify_url\": \"https://weixin.qq.com\",\n  \"funds_account\": \"AVAILABLE\",\n  \"amount\": {\n    \"refund\": 888,\n    \"from\": [\n      {\n        \"account\": \"AVAILABLE\",\n        \"amount\": 444\n      }\n    ],\n    \"total\": 888,\n    \"currency\": \"CNY\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询单笔退款",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds",
+										"{{此处替换为要查询的商户自己生成的退款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds",
+												"{{此处替换为要查询的商户自己生成的退款单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "申请交易账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"tradebill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										},
+										{
+											"key": "bill_type",
+											"value": "ALL",
+											"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"tradebill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												},
+												{
+													"key": "bill_type",
+													"value": "ALL",
+													"description": "不填则默认是ALL，枚举值：\nALL：返回当日所有订单信息（不含充值退款订单）\nSUCCESS：返回当日成功支付的订单（不含充值退款订单）\nREFUND：返回当日退款订单（不含充值退款订单）"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\n    \"hash_type\": \"SHA1\", ///哈希类型\t\n    \"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\t\n}"
+								}
+							]
+						},
+						{
+							"name": "申请资金账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"bill",
+										"fundflowbill"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-12-31",
+											"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"bill",
+												"fundflowbill"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2020-12-31",
+													"description": "格式yyyy-MM-dd，仅支持三个月内的账单下载申请。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "下载账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+									"protocol": "https",
+									"host": [
+										"api",
+										"mch",
+										"weixin",
+										"qq",
+										"com"
+									],
+									"path": [
+										"v3",
+										"billdownload",
+										"file"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"description": "通过申请账单接口获取到“download_url”，URL有效期30s"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"protocol": "https",
+											"host": [
+												"api",
+												"mch",
+												"weixin",
+												"qq",
+												"com"
+											],
+											"path": [
+												"v3",
+												"billdownload",
+												"file"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "交易时间,公众账号ID,商户号,设备号,微信订单号,商户订单号,用户标识,交易类型,交易状态,付款银行,货币种类,应结订单金额,代金券金额,微信退款单号,商户退款单号,退款金额,充值券退款金额,退款类型,退款状态,商品名称,商户数据包,手续费,费率,订单金额,申请退款金额,费率备注\n`2022-10-30 20:12:31,`wxdace645e0bc2cXXX,`1900006XXX,`,`4200000891202103228088184743,`Tencentwechatpay0000001,`obNGB5XGH29T8l1SzegeEZh1HHm0,`JSAPI,`SUCCESS,`OTHERS,`CNY,`50.00,`0.00,`0,`0,`0.00,`0.00,`,`,`汾酒53°;,`,`0.19000,`0.38%,`50.00,`0.00,`\n`2022-10-30 13:29:42,`wxdace645e0bc2cXXX,`1900006XXX,,`,`4200000891202103228088184741,`Tencentwechatpay0000002,`obNGB5Vefw_48hZPE27U33dA-tOk,`JSAPI,`SUCCESS,`OTHERS,`CNY,`135.00,`0.00,`0,`0,`0.00,`0.00,`,`,`泰谷;,`,`0.51000,`0.38%,`135.00,`0.00,`\n总交易单数,应结订单总金额,退款总金额,充值券退款总金额,手续费总金额,订单总金额,申请退款总金额\n`2,`185.00,`0.00,`0.00,`0.70000,`185.00,`0.00\n"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "经营能力",
+			"item": [
+				{
+					"name": "支付即服务",
+					"item": [
+						{
+							"name": "服务人员注册",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_1.shtml\n   接口说明：用于商户开发者为商户注册服务人员使用。调用接口前商家需完成支付即服务产品的开通和设置。若服务商为特约商户调用接口，需在特约商户开通并完成产品设置后，与特约商户建立产品授权关系。 */\n{\n  \"store_id\" : 1234,///门店在微信支付商户平台的唯一标识（查找路径：登录商户平台—>营销中心—>门店管理，若无门店则需先创建门店）\n  \"corpid\" : \"1234567890\",///商户的企业微信唯一标识\n  \"name\" : \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///员工在商户企业微信通讯录上的姓名,需使用微信支付平台公钥加密\n  \"mobile\" : \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///员工在商户企业微信通讯录上的手机号,需使用微信支付平台公钥加密\n  \"qr_code\" : \"https://open.work.weixin.qq.com/wwopen/userQRCode?vcode=xxx\",///员工在商户企业微信通讯录上的二维码串\n  \"avatar\" : \"http://wx.qlogo.cn/mmopen/ajNVdqHZLLA3WJ6DSZUfiakYe37PKnQhBIeOQBO4czqrnZDS79FH5Wm5m4X69TBicnHFlhiafvDwklOpZeXYQQ2icg/0\", ///员工在商户企业微信通讯录上头像的URL\n  \"group_qrcode\" : \"http://p.qpic.cn/wwhead/nMl9ssowtibVGyrmvBiaibzDtp/0\",///员工所在门店在企业微信配置的群活码的URL\n  \"userid\" : \"robert\"///员工在商户企业微信通讯录使用的唯一标识（企业微信的员工信息可通过接口从企业微信通讯录获取，具体请参考企业微信的API文档https://developer.work.weixin.qq.com/document/path/90196 ）\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/smartguide/guides",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"smartguide",
+										"guides"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_1.shtml\n   接口说明：用于商户开发者为商户注册服务人员使用。调用接口前商家需完成支付即服务产品的开通和设置。若服务商为特约商户调用接口，需在特约商户开通并完成产品设置后，与特约商户建立产品授权关系。 */\n{\n  \"store_id\" : 1234,///门店在微信支付商户平台的唯一标识（查找路径：登录商户平台—>营销中心—>门店管理，若无门店则需先创建门店）\n  \"corpid\" : \"1234567890\",///商户的企业微信唯一标识\n  \"name\" : \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///员工在商户企业微信通讯录上的姓名,需使用微信支付平台公钥加密\n  \"mobile\" : \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///员工在商户企业微信通讯录上的手机号,需使用微信支付平台公钥加密\n  \"qr_code\" : \"https://open.work.weixin.qq.com/wwopen/userQRCode?vcode=xxx\",///员工在商户企业微信通讯录上的二维码串\n  \"avatar\" : \"http://wx.qlogo.cn/mmopen/ajNVdqHZLLA3WJ6DSZUfiakYe37PKnQhBIeOQBO4czqrnZDS79FH5Wm5m4X69TBicnHFlhiafvDwklOpZeXYQQ2icg/0\", ///员工在商户企业微信通讯录上头像的URL\n  \"group_qrcode\" : \"http://p.qpic.cn/wwhead/nMl9ssowtibVGyrmvBiaibzDtp/0\",///员工所在门店在企业微信配置的群活码的URL\n  \"userid\" : \"robert\"///员工在商户企业微信通讯录使用的唯一标识（企业微信的员工信息可通过接口从企业微信通讯录获取，具体请参考企业微信的API文档https://developer.work.weixin.qq.com/document/path/90196 ）\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/smartguide/guides",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"smartguide",
+												"guides"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"guide_id\": \"LLA3WJ6DSZUfiaZDS79FH5Wm5m4X69TBic\" ///服务人员ID:服务人员在服务人员系统中的唯一标识\n}"
+								}
+							]
+						},
+						{
+							"name": "服务人员分配",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_2.shtml\n   接口说明：用于商户开发者在顾客下单后为顾客分配服务人员使用。\n   注意：调用服务人员分配接口需在完成支付之前，若分配服务人员晚于支付完成，则将无法在支付凭证上出现服务人员名片入口。 */\n\n{\n  \"out_trade_no\" : \"Tencentwechatpay0000001\" \n  ///商户系统内部订单号，要求32个字符内，仅支持使用字母、数字、中划线-、下划线_、竖线|、星号*这些英文半角字符的组合，请勿使用汉字或全角等特殊字符，且在同一个商户号下唯一。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/smartguide/guides/{{请把此处替换服务人员ID}}/assign",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"smartguide",
+										"guides",
+										"{{请把此处替换服务人员ID}}",
+										"assign"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_2.shtml\n   接口说明：用于商户开发者在顾客下单后为顾客分配服务人员使用。\n   注意：调用服务人员分配接口需在完成支付之前，若分配服务人员晚于支付完成，则将无法在支付凭证上出现服务人员名片入口。 */\n\n{\n  \"out_trade_no\" : \"Tencentwechatpay0000001\" \n  ///商户系统内部订单号，要求32个字符内，仅支持使用字母、数字、中划线-、下划线_、竖线|、星号*这些英文半角字符的组合，请勿使用汉字或全角等特殊字符，且在同一个商户号下唯一。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/smartguide/guides/{{请在此处替换服务人员ID}}/assign",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"smartguide",
+												"guides",
+												"{{请在此处替换服务人员ID}}",
+												"assign"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "服务人员查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/smartguide/guides?store_id=1234",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"smartguide",
+										"guides"
+									],
+									"query": [
+										{
+											"key": "store_id",
+											"value": "1234",
+											"description": "门店在微信支付商户平台的唯一标识（查找路径：登录商户平台—>营销中心—>门店管理，若无门店则需先创建门店）"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/smartguide/guides?store_id=1234",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"smartguide",
+												"guides"
+											],
+											"query": [
+												{
+													"key": "store_id",
+													"value": "1234",
+													"description": "门店在微信支付商户平台的唯一标识（查找路径：登录商户平台—>营销中心—>门店管理，若无门店则需先创建门店）"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/// 参数说明请看https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_3.shtml\n{\n    \"data\": [\n        {\n            \"guide_id\": \"LLA3WJ6DSZUfiaZDS79FH5Wm5m4X69TBic\",\n            \"store_id\": 1234,\n            \"name\": \"str2WUc3Z83uMVcFQu38y9EcWR12FJ3jip5nyVKiqCF4iDSN+JRXjWsWlqTZ0Y8Q+piBCS5ACusK6nz7mKQeypi9fKjAggRfvNFPf/bNxPvork4mMVgZkA==\",\n            \"mobile\": \"str2WoWyZ83uMVcFQu38y9EcWR12FJ3jip5nyVKiqCF4iDSN+JRXjWsWlqTZ0Y8Q+piBCS5ACusK6nz7mKQeypi9fKjAggRfvNFPf/bNxPvork4mMVgZkA==\",\n            \"work_id\": \"robert\"\n        },\n        {\n            \"guide_id\": \"LLA3WJ6DSZUfiaZDS79FH5Wm5m4X69TBic\",\n            \"store_id\": 1234,\n            \"name\": \"str2WUc3Z83uMVcFQu38y9EcWR12FJ3jip5nyVKiqCF4iDSN+JRXjWsWlqTZ0Y8Q+piBCS5ACusK6nz7mKQeypi9fKjAggRfvNFPf/bNxPvork4mMVgZkA==\",\n            \"mobile\": \"str2WoWyZ83uMVcFQu38y9EcWR12FJ3jip5nyVKiqCF4iDSN+JRXjWsWlqTZ0Y8Q+piBCS5ACusK6nz7mKQeypi9fKjAggRfvNFPf/bNxPvork4mMVgZkA==\",\n            \"userid\": \"robert\"\n        }\n    ],\n    \"total_count\": 2,\n    \"limit\": 5,\n    \"offset\": 0\n}"
+								}
+							]
+						},
+						{
+							"name": "服务人员信息更新",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_4.shtml\n   接口说明：用于商户开发者为商户更新门店服务人员的姓名、头像等信息 */\n{\n  \"name\": \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///需更新的服务人员姓名，不更新无需传入，该字段请使用微信支付平台公钥加密，特殊规则：加密前字段长度限制为64个字节\n  \"mobile\": \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///需更新的服务人员手机号码，不更新无需传入，该字段请使用微信支付平台公钥加密，特殊规则：加密前字段长度限制为32个字节\n  \"qr_code\": \"https://open.work.weixin.qq.com/wwopen/userQRCode?vcode=xxx\", ///需更新的服务人员二维码，不更新无需传入，企业微信商家适用，个人微信商家不可用\n  \"avatar\": \"http://wx.qlogo.cn/mmopen/ajNVdqHZLLA3WJ6DSZUfiakYe37PKnQhBIeOQBO4czqrnZDS79FH5Wm5m4X69TBicnHFlhiafvDwklOpZeXYQQ2icg/0\",///需更新的服务人员头像URL，不更新无需传入\n  \"group_qrcode\" : \"http://p.qpic.cn/wwhead/nMl9ssowtibVGyrmvBiaibzDtp/0\" ///员工所在门店在企业微信配置的群活码的URL\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/smartguide/guides/{{请将此处替换为服务人员ID}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"smartguide",
+										"guides",
+										"{{请将此处替换为服务人员ID}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "行业方案",
+			"item": [
+				{
+					"name": "智慧商圈",
+					"item": [
+						{
+							"name": "商圈会员积分同步",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_6_2.shtml\n   接口说明：通过此API，商圈商户/服务商可针对微信支付前序推送给商圈系统的会员支付结果通知，告知微信支付系统该笔交易的会员积分情况。 */\n{\n   \"transaction_id\": \"4200000533202000000000000000\", ///微信支付推送的商圈内交易通知里携带的微信订单号\n   \"appid\": \"{{appid}}\", ///顾客授权积分时使用的小程序的appid\n   \"openid\": \"{{openid}}\", ///顾客授权时使用的小程序获取到的openid\n   \"earn_points\": true, ///用于标明此单是否获得积分，true为获得积分，false为未获得\n   \"increased_points\": 100,///顾客此笔交易新增的积分值 \n   \"points_update_time\": \"2022-12-31T23:29:35.120+08:00\", ///为顾客此笔交易成功积分的时间\n   \"total_points\": 888888 ///当前顾客积分总额\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/businesscircle/points/notify",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"businesscircle",
+										"points",
+										"notify"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_6_2.shtml\n   接口说明：通过此API，商圈商户/服务商可针对微信支付前序推送给商圈系统的会员支付结果通知，告知微信支付系统该笔交易的会员积分情况。 */\n{\n   \"transaction_id\": \"4200000533202000000000000000\", ///微信支付推送的商圈内交易通知里携带的微信订单号\n   \"appid\": \"{{appid}}\", ///顾客授权积分时使用的小程序的appid\n   \"openid\": \"{{openid}}\", ///顾客授权时使用的小程序获取到的openid\n   \"earn_points\": true, ///用于标明此单是否获得积分，true为获得积分，false为未获得\n   \"increased_points\": 100,///顾客此笔交易新增的积分值 \n   \"points_update_time\": \"2022-12-31T23:29:35.120+08:00\", ///为顾客此笔交易成功积分的时间\n   \"total_points\": 888888 ///当前顾客积分总额\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/businesscircle/points/notify",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"businesscircle",
+												"points",
+												"notify"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "商圈会员积分服务授权查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/businesscircle/user-authorizations/{{此处替换为要查询的openid}}?appid={{appid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"businesscircle",
+										"user-authorizations",
+										"{{此处替换为要查询的openid}}"
+									],
+									"query": [
+										{
+											"key": "appid",
+											"value": "{{appid}}",
+											"description": "顾客授权积分时使用的小程序的appid,记得替换自己要查询使用的APPID"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/businesscircle/user-authorizations/{{此处替换为要查询的openid}}?appid={{appid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"businesscircle",
+												"user-authorizations",
+												"{{此处替换为要查询的openid}}"
+											],
+											"query": [
+												{
+													"key": "appid",
+													"value": "{{appid}}",
+													"description": "顾客授权积分时使用的小程序的appid,记得替换自己要查询使用的APPID"
+												}
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"openid\": \"oWmnN4xxxxxxxxxxe92NHIGf1xd8\", ///顾客授权时使用的小程序上的openid\n  \"authorize_state\": \"AUTHORIZED\", ///授权状态，顾客授权商圈积分结果：UNAUTHORIZED：未授权，AUTHORIZED：已授权，DEAUTHORIZED：已取消授权\n  \"authorize_time\": \"2020-05-20T13:29:35+08:00\" ///顾客成功授权商圈积分的时间\n}"
+								}
+							]
+						},
+						{
+							"name": "商圈会员待积分状态查询",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/businesscircle/users/{{此处替换为要查询的openid}}/points/commit_status?brandid=1000&appid={{appid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"businesscircle",
+										"users",
+										"{{此处替换为要查询的openid}}",
+										"points",
+										"commit_status"
+									],
+									"query": [
+										{
+											"key": "brandid",
+											"value": "1000",
+											"description": "调用方商户号对应的品牌brandid，调用方商户号需为此品牌brandid的品牌主商户号或品牌服务商商户号"
+										},
+										{
+											"key": "appid",
+											"value": "{{appid}}",
+											"description": "支持服务号、小程序等类型的AppID，需已与brandid完成下单AppID绑定"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/businesscircle/users/{{此处替换为要查询的openid}}/points/commit_status?brandid=1000&appid={{appid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"businesscircle",
+												"users",
+												"{{此处替换为要查询的openid}}",
+												"points",
+												"commit_status"
+											],
+											"query": [
+												{
+													"key": "brandid",
+													"value": "1000",
+													"description": "调用方商户号对应的品牌brandid，调用方商户号需为此品牌brandid的品牌主商户号或品牌服务商商户号"
+												},
+												{
+													"key": "appid",
+													"value": "{{appid}}",
+													"description": "支持服务号、小程序等类型的AppID，需已与brandid完成下单AppID绑定"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"points_commit_status\": \"PENDING\"\n  /* 商圈会员待积分状态\n    PENDING：有积分待提交，商圈会员有待提交的积分记录，可引导会员跳转插件提交积分申请\n    FINISHED：无积分可提交，商圈会员没有待提交的积分记录 */\n}"
+								}
+							]
+						},
+						{
+							"name": "商圈会员停车状态同步",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_6_5.shtml\n   接口说明：通过此API，商圈商户/服务商可将会员的停车状态同步给微信支付，以辅助判断用户到场，用户在商圈内门店消费可自动积商圈会员积分。 */\n{\n  \"appid\": \"{{appid}}\", ///支持服务号、小程序等类型的AppID，需已与brandid完成下单AppID绑定\n  \"brandid\": 1000,///调用方商户号对应的品牌brandid，调用方商户号需为此品牌brandid的品牌主商户号或品牌服务商商户号\n  \"openid\": \"{{openid}}\", ///用户在商户对应AppID下的唯一标识\n  \"plate_number\": \"粤B888888\",///首位需为省份的中文简称，第二位起支持大写字母、数字、中文\n  \"state\": \"IN\", ///停车状态，服务商模式下必传 IN：入场，用户开车进入商圈  OUT：离场，用户开车离开商圈\n  \"time\": \"2022-06-01T10:43:39+08:00\" ///在场状态更新时间，按照使用rfc3339所定义的格式，格式为yyyy-MM-DDThh:mm:ss+TIMEZONE\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/businesscircle/parkings",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"businesscircle",
+										"parkings"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_6_5.shtml\n   接口说明：通过此API，商圈商户/服务商可将会员的停车状态同步给微信支付，以辅助判断用户到场，用户在商圈内门店消费可自动积商圈会员积分。 */\n{\n  \"appid\": \"{{appid}}\", ///支持服务号、小程序等类型的AppID，需已与brandid完成下单AppID绑定\n  \"brandid\": 1000,///调用方商户号对应的品牌brandid，调用方商户号需为此品牌brandid的品牌主商户号或品牌服务商商户号\n  \"openid\": \"{{openid}}\", ///用户在商户对应AppID下的唯一标识\n  \"plate_number\": \"粤B888888\",///首位需为省份的中文简称，第二位起支持大写字母、数字、中文\n  \"state\": \"IN\", ///停车状态，服务商模式下必传 IN：入场，用户开车进入商圈  OUT：离场，用户开车离开商圈\n  \"time\": \"2022-06-01T10:43:39+08:00\" ///在场状态更新时间，按照使用rfc3339所定义的格式，格式为yyyy-MM-DDThh:mm:ss+TIMEZONE\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/businesscircle/parkings",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"businesscircle",
+												"parkings"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "微信支付分停车服务",
+					"item": [
+						{
+							"name": "查询车牌服务开通信息",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/vehicle/parking/services/find?appid={{appid}}&plate_number=%E7%B2%A4B888888&plate_color=BLUE&openid={{openid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"vehicle",
+										"parking",
+										"services",
+										"find"
+									],
+									"query": [
+										{
+											"key": "appid",
+											"value": "{{appid}}",
+											"description": "商户号绑定的APPID"
+										},
+										{
+											"key": "plate_number",
+											"value": "%E7%B2%A4B888888",
+											"description": "车牌号，仅包括省份+车牌，不包括特殊字符，需要格式化"
+										},
+										{
+											"key": "plate_color",
+											"value": "BLUE",
+											"description": "车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色"
+										},
+										{
+											"key": "openid",
+											"value": "{{openid}}",
+											"description": "用户在商户对应appid下的唯一标识"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/vehicle/parking/services/find?appid={{appid}}&plate_number=%E7%B2%A4B888888&plate_color=BLUE&openid={{openid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"vehicle",
+												"parking",
+												"services",
+												"find"
+											],
+											"query": [
+												{
+													"key": "appid",
+													"value": "{{appid}}",
+													"description": "商户号绑定的APPID"
+												},
+												{
+													"key": "plate_number",
+													"value": "%E7%B2%A4B888888",
+													"description": "车牌号，仅包括省份+车牌，不包括特殊字符，需要格式化"
+												},
+												{
+													"key": "plate_color",
+													"value": "BLUE",
+													"description": "车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色"
+												},
+												{
+													"key": "openid",
+													"value": "{{openid}}",
+													"description": "用户在商户对应appid下的唯一标识"
+												}
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "///接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_1.shtml\n{\n    \"plate_number\": \"粤B888888\", ///车牌号，仅包括省份+车牌，不包括特殊字符。\n    \"plate_color\": \"BLUE\",///车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色\n    \"service_open_time\": \"2017-08-26T10:43:39+08:00\", ///车牌服务开通时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，\n    \"openid\": \"oUpF8uMuAJOM2pxb1Q\", ///用户在商户对应appid下的唯一标识，此处返回商户请求中的openid\n    \"service_state\": \"PAUSE\" \n    /*车牌服务开通状态，NORMAL：正常服务 PAUSE：暂停服务， OUT_SERVICE：未开通，商户根据状态带用户跳转至对应的微信支付分停车服务小程序页面。其中NORMAL 和 PAUSE状态，可跳转至车牌管理页，进行车牌服务状态管理。OUT_SERVICE状态，可跳转至服务开通页面。 */\n}"
+								}
+							]
+						},
+						{
+							"name": "创建停车入场",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_2.shtml\n   接口说明：车辆入场以后，商户调用该接口，创建停车入场信息。 */\n{\n  \"out_parking_no\": \"1231243\", ///商户侧入场标识id，在同一个商户号下需要保证唯一\n  \"plate_number\": \"粤B888888\", ///车牌号，仅包括省份+车牌，不包括特殊字符。\n  \"plate_color\": \"BLUE\", ///车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色\n  \"notify_url\": \"https://yoursite.com/wxpay.html\", ///接受入场状态变更回调通知的url，注意回调url只接受https\n  \"start_time\": \"2017-08-26T10:43:39+08:00\", ///入场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"parking_name\": \"欢乐海岸停车场\", ///所在停车位车场的名称\n  \"free_duration\": 3600 ///停车场的免费停车时长，注意单位为“秒”\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/vehicle/parking/parkings",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"vehicle",
+										"parking",
+										"parkings"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_2.shtml\n   接口说明：车辆入场以后，商户调用该接口，创建停车入场信息。 */\n{\n  \"out_parking_no\": \"1231243\", ///商户侧入场标识id，在同一个商户号下需要保证唯一\n  \"plate_number\": \"粤B888888\", ///车牌号，仅包括省份+车牌，不包括特殊字符。\n  \"plate_color\": \"BLUE\", ///车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色\n  \"notify_url\": \"https://yoursite.com/wxpay.html\", ///接受入场状态变更回调通知的url，注意回调url只接受https\n  \"start_time\": \"2017-08-26T10:43:39+08:00\", ///入场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"parking_name\": \"欢乐海岸停车场\", ///所在停车位车场的名称\n  \"free_duration\": 3600 ///停车场的免费停车时长，注意单位为“秒”\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/vehicle/parking/parkings",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"vehicle",
+												"parking",
+												"parkings"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"id\": \"5K8264ILTKCH16CQ250\", ///车主服务为商户分配的入场id\n    \"out_parking_no\": \"212434321\", ///商户侧入场标识id，在同一个商户号下唯一,此处返回的为商户所传单号\n    \"plate_number\": \"粤B888888\", ///车牌号，仅包括省份+车牌，不包括特殊字符。\n    \"plate_color\": \"BLUE\", //////车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色\n    \"start_time\": \"2017-08-26T10:43:39+08:00\", //////入场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"parking_name\": \"欢乐海岸停车场\",  ///所在停车位车场的名称\n    \"free_duration\": 3600, ///停车场的免费停车时长，注意单位为“秒”\n    \"state\": \"NORMAL\", ///本次入场车牌的服务状态，NORMAL：正常状态，可以使用微信支付分停车服务， BLOCKED：不可用状态，暂时不可以使用微信支付分停车服务\n    \"block_reason\": \"PAUSE\" \n    /*block服务状态描述，返回车牌状态为BLOCKED，会返回该字段，描述具体BLOCKED的原因，\n    PAUSE：已暂停微信支付分停车服务；\n    OVERDUE：已授权签约但欠费，不能提供服务,\n    OUT_SERVICE：车牌未开通微信支付分停车服务，\n    EVALUATION_FAILED：综合评估未通过，用户支付分不可用的情况，会返回该状态。 */\n}"
+								}
+							]
+						},
+						{
+							"name": "扣费受理",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_3.shtml\n   接口说明：商户请求扣费受理接口，会完成订单受理。微信支付进行异步扣款，支付完成后，会将订单支付结果发送给商户。 */\n{\n  \"appid\": \"{{appid}}\", ///商户号绑定的APPID，需要与请求头商户号存在绑定关系\n  \"description\": \"停车场扣费\", ///商户自定义字段，用于交易账单中对扣费服务的描述。\n  \"attach\": \"深圳分店\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n  \"out_trade_no\": \"20150806125346\", ///商户系统内部订单号，只能是数字、大小写字母，需要在商户号下保证唯一\n  \"trade_scene\": \"PARKING\", ///交易场景值，目前支持PARKING：车场停车场景\n  \"goods_tag\": \"WXG\", ///金券或立减优惠功能的参数，说明详见 代金券或立减优惠\n  \"notify_url\": \"https://yoursite.com/wxpay.html\", ///接受扣款结果异步回调通知的url，注意回调url只接受https\n  \"profit_sharing\": \"Y\", ///枚举值：Y：是，需要分账 N：否，不分账 （此处未测试，如Y/N 报错，可以尝试传true或者false）\n  \"amount\": {\n    \"total\": 888, ///订单总金额，单位为“分”，只能为整数\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY\n  },\n  \"parking_info\": {\n    \"parking_id\": \"5K8264ILTKCH16CQ250\", ///微信支付分停车服务为商户分配的入场id，商户通过入场通知接口获取入场id\n    \"plate_number\": \"粤B888888\", /////车牌号，仅包括省份+车牌，不包括特殊字符。\n    \"plate_color\": \"BLUE\", ///车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色\n    \"start_time\": \"2017-08-26T10:43:39+08:00\", ///用户入场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"end_time\": \"2017-08-26T10:43:39+08:00\", ///用户出场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"parking_name\": \"欢乐海岸停车场\", ///所在停车位车场的名称\n    \"charging_duration\": 3600, ///计费的时间长，单位为秒\n    \"device_id\": \"12313\" ///停车场设备id\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/vehicle/transactions/parking",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"vehicle",
+										"transactions",
+										"parking"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_3.shtml\n   接口说明：商户请求扣费受理接口，会完成订单受理。微信支付进行异步扣款，支付完成后，会将订单支付结果发送给商户。 */\n{\n  \"appid\": \"{{appid}}\", ///商户号绑定的APPID，需要与请求头商户号存在绑定关系\n  \"description\": \"停车场扣费\", ///商户自定义字段，用于交易账单中对扣费服务的描述。\n  \"attach\": \"深圳分店\", ///附加数据，在查询API和支付通知中原样返回，可作为自定义参数使用，实际情况下只有支付完成状态才会返回该字段。\n  \"out_trade_no\": \"20150806125346\", ///商户系统内部订单号，只能是数字、大小写字母，需要在商户号下保证唯一\n  \"trade_scene\": \"PARKING\", ///交易场景值，目前支持PARKING：车场停车场景\n  \"goods_tag\": \"WXG\", ///金券或立减优惠功能的参数，说明详见 代金券或立减优惠\n  \"notify_url\": \"https://yoursite.com/wxpay.html\", ///接受扣款结果异步回调通知的url，注意回调url只接受https\n  \"profit_sharing\": \"Y\", ///枚举值：Y：是，需要分账 N：否，不分账 （此处未测试，如Y/N 报错，可以尝试传true或者false）\n  \"amount\": {\n    \"total\": 888, ///订单总金额，单位为“分”，只能为整数\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY\n  },\n  \"parking_info\": {\n    \"parking_id\": \"5K8264ILTKCH16CQ250\", ///微信支付分停车服务为商户分配的入场id，商户通过入场通知接口获取入场id\n    \"plate_number\": \"粤B888888\", /////车牌号，仅包括省份+车牌，不包括特殊字符。\n    \"plate_color\": \"BLUE\", ///车牌颜色，枚举值：BLUE：蓝色 GREEN：绿色 YELLOW：黄色 BLACK：黑色 WHITE：白色 LIMEGREEN：黄绿色\n    \"start_time\": \"2017-08-26T10:43:39+08:00\", ///用户入场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"end_time\": \"2017-08-26T10:43:39+08:00\", ///用户出场时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"parking_name\": \"欢乐海岸停车场\", ///所在停车位车场的名称\n    \"charging_duration\": 3600, ///计费的时间长，单位为秒\n    \"device_id\": \"12313\" ///停车场设备id\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/vehicle/transactions/parking",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"vehicle",
+												"transactions",
+												"parking"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "\b/* 回参说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_3.shtml */\n{\n  \"appid\": \"wxcbda96de0b165486\",\n  \"sp_mchid\": \"1230000109\",\n  \"description\": \"停车场扣费\",\n  \"create_time\": \"2017-08-26T10:43:39+08:00\",\n  \"out_trade_no\": \"20150806125346\",\n  \"transaction_id\": \"1009660380201506130728806387\",\n  \"trade_state\": \"SUCCESS\",\n  \"trade_state_description\": \"支付失败，请重新下单支付\",\n  \"success_time\": \"2017-08-26T10:43:39+08:00\",\n  \"bank_type\": \"CMC\",\n  \"user_repaid\": \"Y\",\n  \"attach\": \"深圳分店\",\n  \"trade_scene\": \"PARKING\",\n  \"parking_info\": {\n    \"parking_id\": \"5K8264ILTKCH16CQ250\",\n    \"plate_number\": \"粤B888888\",\n    \"plate_color\": \"BLUE\",\n    \"start_time\": \"2017-08-26T10:43:39+08:00\",\n    \"end_time\": \"2017-08-26T10:43:39+08:00\",\n    \"parking_name\": \"欢乐海岸停车场\",\n    \"charging_duration\": 3600,\n    \"device_id\": \"12313\"\n  },\n  \"payer\": {\n    \"openid\": \"oUpF8uMuAJOM2pxb1Q\",\n  },\n  \"amount\": {\n    \"total\": 888,\n    \"currency\": \"CNY\",\n    \"payer_total\": 100,\n    \"discount_total\": 100\n  },\n  \"promotion_detail\": [\n    {\n      \"coupon_id\": \"109519\",\n      \"name\": \"单品惠-6\",\n      \"scope\": \"SINGLE\",\n      \"type\": \"CASH\",\n      \"stock_id\": \"931386\",\n      \"amount\": 5,\n      \"wechatpay_contribute\": 1,\n      \"merchant_contribute\": 1,\n      \"other_contribute\": 1,\n      \"currency\": \"CNY\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询订单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/vehicle/transactions/out-trade-no/{{此处替换为你要查询的订单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"vehicle",
+										"transactions",
+										"out-trade-no",
+										"{{此处替换为你要查询的订单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/vehicle/transactions/out-trade-no/20150806125346",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"vehicle",
+												"transactions",
+												"out-trade-no",
+												"20150806125346"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "\b/* 回参说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_4.shtml */\n{\n  \"appid\": \"wxcbda96de0b165486\",\n  \"sp_mchid\": \"1230000109\",\n  \"description\": \"停车场扣费\",\n  \"create_time\": \"2017-08-26T10:43:39+08:00\",\n  \"out_trade_no\": \"20150806125346\",\n  \"transaction_id\": \"1009660380201506130728806387\",\n  \"trade_state\": \"SUCCESS\",\n  \"trade_state_description\": \"支付失败，请重新下单支付\",\n  \"success_time\": \"2017-08-26T10:43:39+08:00\",\n  \"bank_type\": \"CMC\",\n  \"user_repaid\": \"Y\",\n  \"attach\": \"深圳分店\",\n  \"trade_scene\": \"PARKING\",\n  \"parking_info\": {\n    \"parking_id\": \"5K8264ILTKCH16CQ250\",\n    \"plate_number\": \"粤B888888\",\n    \"plate_color\": \"BLUE\",\n    \"start_time\": \"2017-08-26T10:43:39+08:00\",\n    \"end_time\": \"2017-08-26T10:43:39+08:00\",\n    \"parking_name\": \"欢乐海岸停车场\",\n    \"charging_duration\": 3600,\n    \"device_id\": \"12313\"\n  },\n  \"payer\": {\n    \"openid\": \"oUpF8uMuAJOM2pxb1Q\",\n  },\n  \"amount\": {\n    \"total\": 888,\n    \"currency\": \"CNY\",\n    \"payer_total\": 100,\n    \"discount_total\": 100\n  },\n  \"promotion_detail\": [\n    {\n      \"coupon_id\": \"109519\",\n      \"name\": \"单品惠-6\",\n      \"scope\": \"SINGLE\",\n      \"type\": \"CASH\",\n      \"stock_id\": \"931386\",\n      \"amount\": 5,\n      \"wechatpay_contribute\": 1,\n      \"merchant_contribute\": 1,\n      \"other_contribute\": 1,\n      \"currency\": \"CNY\"\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "申请退款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_11.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_8_11.shtml\n   接口说明：当交易发生之后一年内，由于买家或者卖家的原因需要退款时，卖家可以通过退款接口将支付金额退还给买家，微信支付将在收到退款请求并且验证成功之后，将支付款按原路退还至买家账号上。 */\n{\n  \"transaction_id\": \"4200000891202103228088184743\", ///支付成功后微信返回的微信支付订单号,也可以使用商户订单号发起退款，参数为“out_trade_no”\n  \"out_refund_no\": \"1217752501201407033233368018\", ///商户系统内部的退款单号，商户号下需要保持唯一，只能是数字、大小写字母_-|*@ ，注意：同一退款单号多次请求只退一笔。\n  \"reason\": \"商品已售完\", ///非必传，若商户传入，会在下发给用户的退款消息中体现退款原因\n  \"notify_url\": \"https://weixin.qq.com\", ///异步接收微信支付退款结果通知的回调地址，通知url必须为外网可访问的url，不能携带参数。 如果参数中传了notify_url，则商户平台上配置的回调地址将不会生效，优先回调当前传的这个地址。\n  \"amount\": {\n    \"refund\": 888, ///退款金额，单位为分\n    \"total\": 888, ///原支付交易的订单总金额，单位为分，只能为整数。\n    \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询单笔退款",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的退款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"refund",
+										"domestic",
+										"refunds",
+										"{{此处替换为要查询的退款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的退款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"refund",
+												"domestic",
+												"refunds",
+												"{{此处替换为要查询的退款单号}}"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "营销工具",
+			"item": [
+				{
+					"name": "代金券",
+					"item": [
+						{
+							"name": "创建代金券批次",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_1.shtml\n   接口说明：商户可以通过调用此接口创建微信支付代金券批次，包括预充值&免充值代金券；创建完成后将获得代金券批次id，将可用于各个营销场景的活动投放。 */\n{\n    \"stock_name\": \"请认真阅读文档\", ///批次名称 校验规则：1、批次名称最多9个中文汉字 2、批次名称最多20个字母 3、批次名称中不能包含不当内容和特殊字符 _ , ; |\n    \"comment\": \"零售批次\", ///该字段仅制券商户可见，用于自定义信息。校验规则：批次备注最多60个UTF8字符数\n    \"belong_merchant\": \"{{mchid}}\", ///批次归属商户号 本字段暂未开放生效，但入参时请设置为当前创建代金券商户号即不会报错，暂时不支持入参其他的商户号\n    \"available_begin_time\": \"2022-11-11T00:00:01.000+08:00\", ///批次开始时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE 校验规则：1、开始时间不可早于当前时间 2、不能创建365天后开始的批次 3、批次可用时间范围最长为90天\n    \"available_end_time\": \"2022-11-30T23:59:59.000+08:00\", ///批次结束时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE 校验规则：1、开始时间不可早于当前时间 2、不能创建365天后开始的批次 3、批次可用时间范围最长为90天\n    \"stock_use_rule\": {\n        \"max_coupons\": 10, ///最大发券数 校验规则：1、发放总个数最少5个 2、发放总个数最多1000万个\n        \"max_amount\": 5000, ///最大发券预算，当营销经费no_cash选择预充值false时，激活批次时会从制券商户的余额中扣除预算，请保证账户金额充足，单位:\"分\" max_amount需要等于coupon_amount（面额） * max_coupons（发放总上限）校验规则：批次总预算最多1000万元\n        \"max_amount_by_day\": 500, ///可不传，如果设置此字段，则指定单天最大发券预算，发放超出会报错，单位：分。校验规则：1、不能大于总预算 2、max_amount_by_day不可以为0\n        \"max_coupons_per_user\": 3,///活动期间每个用户可领张数，当开启了自然人限领时，多个微信号同属于一个身份证时，视为同一用户。校验规则：1、不能大于发放总个数2、最少为1个，最多为60个\n        \"natural_person_limit\": true, ///当开启了自然人限领时，多个微信号同属于一个身份证时，视为同一用户，枚举值 true：是 false：否\n        \"prevent_api_abuse\": true ///若开启防刷拦截，当用户命中恶意、小号、机器、羊毛党、黑产等风险行为时，无法成功发放代金券。枚举值 true：是 false：否\n        },\n    \"pattern_info\": {\n        \"description\": \"仅限在参与文博会定向消费券活动的文旅商家（商家需在深圳地区经营并在深圳开通微信商户号）使用；\\n领取后到店微信支付即可用，无需出示，每次支付限用一张代金券，不折现、不挂失、不找零；请在微信卡券包查看和使用代金券；\\n若享受优惠券的交易发生退款，仅退还用户实际支付的金额（不包含代金券的优惠抵扣金额），已享优惠资格不再补偿。\",\n        ///使用说明：用于说明详细的活动规则，会展示在代金券详情页。校验规则：最多1000个UTF8字符\n        \"merchant_logo\": \"https://wx.gtimg.com/mmpay_pub/KQwOuXiby6RR2Da2oGPMe4ZGjiaC8wdwZUNf9SageS77G8ibicGCdD6S9WIpEBbaibIbq/0\", \n        ///商户logo，可不传 ，仅支持通过《图片上传API》接口获取的图片URL地址。1、商户logo大小需为120像素*120像素。 2、支持JPG/JPEG/PNG格式，且图片小于1M。 3、最多128个UTF8字符\n        \"merchant_name\": \"耗子尾汁\", ///品牌名称，展示在用户卡包 校验规则： 1、最多12个中文汉字 2、最多36个英文字符\n        \"background_color\": \"COLOR060\", ///券的背景颜色，可设置10种颜色，色值请参考卡券背景颜色图。颜色取值为颜色图中的颜色名称。可选枚举字段不用则不传，不可以传空值\n        \"coupon_image\": \"https://wx.gtimg.com/mmpay_pub/KQwOuXiby6RR2Da2oGPMe4ZGjiaC8wdwZUNf9SageS77G8ibicGCdD6S9WIpEBbaibIbq/0\"\n        ///券详情图片，可不传， 850像素*350像素，且图片大小不超过2M，支持JPG/PNG格式，仅支持通过《图片上传API》接口获取的图片URL地址。\n        },\n    \"coupon_use_rule\": {\n        \"fixed_normal_coupon\": {\n            \"coupon_amount\": 500, ///券面额，单位：分。校验规则：1、必须为整数 2、必须大于1元且小于等于500元\n            \"transaction_minimum\": 1000 ///使用券金额门槛，单位：分。若指定可核销商品编码，门槛则为可核销商品部分的消费金额，而不是订单的消费金额。校验规则：使用门槛必须大于优惠金额\n            },\n    \"goods_tag\": [\n        \"my-test\"\n    ],\n    ///goods_tag：订单优惠标记，按json格式。商户下单时需要传入相同的标记(goods_tag)，用户同时符合其他规则才能享受优惠校验规则：1、最多允许录入50个 2、每个订单优惠标记支持字母/数字/下划线，不超过128个UTF8字符。\n    \"combine_use\": true, ///是否允许本优惠可以和本商户号创建的其他券同时使用，不填则默认允许同时使用。枚举值：true：是 false：否\n        \"available_merchants\": [\n            \"{{mchid}}\"\n            ],\n    /*可用商户的交易才可核销/使用代金券。当营销经费no_cash=false时，可用商户允许填入任何类型的特约商户或普通商户\n当营销经费no_cash=true时，分为以下几种情况：\n1、创建商户是普通商户或服务商特约商户(子商户)：可添加本商户号或同品牌商户。\n说明：若可用商户中，有特约商户(子商户)，那么特约商户自己发起的交易、以及服务商帮特约商户发起的交易，都可以使用代金券。\n2、创建商户是普通服务商：可添加已授权的子商户，详见《申请免充值代金券产品权限》。\n说明：特约商户如果有多个服务商，那么服务商为他发起的交易，只要完成了免充值授权，都可以使用代金券；特约商户自己发起的交易不可以使用代金券。\n3、创建商户是渠道商、银行服务商或从业机构：可直接添加旗下任意子商户，不需要子商户授权。\n校验规则：条目个数限制为【1，50】 */\n    \"limit_pay\" :[\"CBHB_DEBIT\"] ///指定付款方式的交易可核销/使用代金券，可指定零钱付款、指定银行卡付款，需填入支付方式编码， 不在此列表中的银行卡，暂不支持此功能。黄色标记部分为不可使用的银行。校验规则：条目个数限制为【1，1】\n    },\n    \"no_cash\": false,/*营销经费。枚举值：true：免充值 false：预充值\n1、免充值：制券方无需提前充值资金，用户核销代金券时，直接从订单原价中扣除优惠减价金额，最终只将用户实际支付的金额结算给核销商户，商户实收少于订单原价。\n2、预充值：制券方需将优惠预算提前充值到微信支付商户可用余额中，用户核销代金券时，系统从制券方商户可用余额中扣除优惠减价部分对应的资金，连同用户实际支付的资金，一并结算给核销商户，不影响实收。 */\n    \"stock_type\": \"NORMAL\", ///批次类型，仅支持：NORMAL：固定面额满减券批次\n    \"out_request_no\": \"TencentCouponStocks0001\" ///商户创建批次凭据号（格式：商户id+日期+流水号），可包含英文字母，数字，|，_，*，-等内容，不允许出现其他不合法符号，商户侧需保持商户单据号全局唯一。\n    }",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/coupon-stocks",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"coupon-stocks"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_1.shtml\n   接口说明：商户可以通过调用此接口创建微信支付代金券批次，包括预充值&免充值代金券；创建完成后将获得代金券批次id，将可用于各个营销场景的活动投放。 */\n{\n    \"stock_name\": \"请认真阅读文档\", ///批次名称 校验规则：1、批次名称最多9个中文汉字 2、批次名称最多20个字母 3、批次名称中不能包含不当内容和特殊字符 _ , ; |\n    \"comment\": \"零售批次\", ///该字段仅制券商户可见，用于自定义信息。校验规则：批次备注最多60个UTF8字符数\n    \"belong_merchant\": \"{{mchid}}\", ///批次归属商户号 本字段暂未开放生效，但入参时请设置为当前创建代金券商户号即不会报错，暂时不支持入参其他的商户号\n    \"available_begin_time\": \"2022-11-11T00:00:01.000+08:00\", ///批次开始时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE 校验规则：1、开始时间不可早于当前时间 2、不能创建365天后开始的批次 3、批次可用时间范围最长为90天\n    \"available_end_time\": \"2022-11-30T23:59:59.000+08:00\", ///批次结束时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE 校验规则：1、开始时间不可早于当前时间 2、不能创建365天后开始的批次 3、批次可用时间范围最长为90天\n    \"stock_use_rule\": {\n        \"max_coupons\": 10, ///最大发券数 校验规则：1、发放总个数最少5个 2、发放总个数最多1000万个\n        \"max_amount\": 5000, ///最大发券预算，当营销经费no_cash选择预充值false时，激活批次时会从制券商户的余额中扣除预算，请保证账户金额充足，单位:\"分\" max_amount需要等于coupon_amount（面额） * max_coupons（发放总上限）校验规则：批次总预算最多1000万元\n        \"max_amount_by_day\": 500, ///可不传，如果设置此字段，则指定单天最大发券预算，发放超出会报错，单位：分。校验规则：1、不能大于总预算 2、max_amount_by_day不可以为0\n        \"max_coupons_per_user\": 3,///活动期间每个用户可领张数，当开启了自然人限领时，多个微信号同属于一个身份证时，视为同一用户。校验规则：1、不能大于发放总个数2、最少为1个，最多为60个\n        \"natural_person_limit\": true, ///当开启了自然人限领时，多个微信号同属于一个身份证时，视为同一用户，枚举值 true：是 false：否\n        \"prevent_api_abuse\": true ///若开启防刷拦截，当用户命中恶意、小号、机器、羊毛党、黑产等风险行为时，无法成功发放代金券。枚举值 true：是 false：否\n        },\n    \"pattern_info\": {\n        \"description\": \"仅限在参与文博会定向消费券活动的文旅商家（商家需在深圳地区经营并在深圳开通微信商户号）使用；\\n领取后到店微信支付即可用，无需出示，每次支付限用一张代金券，不折现、不挂失、不找零；请在微信卡券包查看和使用代金券；\\n若享受优惠券的交易发生退款，仅退还用户实际支付的金额（不包含代金券的优惠抵扣金额），已享优惠资格不再补偿。\",\n        ///使用说明：用于说明详细的活动规则，会展示在代金券详情页。校验规则：最多1000个UTF8字符\n        \"merchant_logo\": \"https://wx.gtimg.com/mmpay_pub/KQwOuXiby6RR2Da2oGPMe4ZGjiaC8wdwZUNf9SageS77G8ibicGCdD6S9WIpEBbaibIbq/0\", \n        ///商户logo，可不传 ，仅支持通过《图片上传API》接口获取的图片URL地址。1、商户logo大小需为120像素*120像素。 2、支持JPG/JPEG/PNG格式，且图片小于1M。 3、最多128个UTF8字符\n        \"merchant_name\": \"耗子尾汁\", ///品牌名称，展示在用户卡包 校验规则： 1、最多12个中文汉字 2、最多36个英文字符\n        \"background_color\": \"COLOR060\", ///券的背景颜色，可设置10种颜色，色值请参考卡券背景颜色图。颜色取值为颜色图中的颜色名称。可选枚举字段不用则不传，不可以传空值\n        \"coupon_image\": \"https://wx.gtimg.com/mmpay_pub/KQwOuXiby6RR2Da2oGPMe4ZGjiaC8wdwZUNf9SageS77G8ibicGCdD6S9WIpEBbaibIbq/0\"\n        ///券详情图片，可不传， 850像素*350像素，且图片大小不超过2M，支持JPG/PNG格式，仅支持通过《图片上传API》接口获取的图片URL地址。\n        },\n    \"coupon_use_rule\": {\n        \"fixed_normal_coupon\": {\n            \"coupon_amount\": 500, ///券面额，单位：分。校验规则：1、必须为整数 2、必须大于1元且小于等于500元\n            \"transaction_minimum\": 1000 ///使用券金额门槛，单位：分。若指定可核销商品编码，门槛则为可核销商品部分的消费金额，而不是订单的消费金额。校验规则：使用门槛必须大于优惠金额\n            },\n    \"goods_tag\": [\n        \"my-test\"\n    ],\n    ///goods_tag：订单优惠标记，按json格式。商户下单时需要传入相同的标记(goods_tag)，用户同时符合其他规则才能享受优惠校验规则：1、最多允许录入50个 2、每个订单优惠标记支持字母/数字/下划线，不超过128个UTF8字符。\n    \"combine_use\": true, ///是否允许本优惠可以和本商户号创建的其他券同时使用，不填则默认允许同时使用。枚举值：true：是 false：否\n        \"available_merchants\": [\n            \"{{mchid}}\"\n            ],\n    /*可用商户的交易才可核销/使用代金券。当营销经费no_cash=false时，可用商户允许填入任何类型的特约商户或普通商户\n当营销经费no_cash=true时，分为以下几种情况：\n1、创建商户是普通商户或服务商特约商户(子商户)：可添加本商户号或同品牌商户。\n说明：若可用商户中，有特约商户(子商户)，那么特约商户自己发起的交易、以及服务商帮特约商户发起的交易，都可以使用代金券。\n2、创建商户是普通服务商：可添加已授权的子商户，详见《申请免充值代金券产品权限》。\n说明：特约商户如果有多个服务商，那么服务商为他发起的交易，只要完成了免充值授权，都可以使用代金券；特约商户自己发起的交易不可以使用代金券。\n3、创建商户是渠道商、银行服务商或从业机构：可直接添加旗下任意子商户，不需要子商户授权。\n校验规则：条目个数限制为【1，50】 */\n    \"limit_pay\" :[\"CBHB_DEBIT\"] ///指定付款方式的交易可核销/使用代金券，可指定零钱付款、指定银行卡付款，需填入支付方式编码， 不在此列表中的银行卡，暂不支持此功能。黄色标记部分为不可使用的银行。校验规则：条目个数限制为【1，1】\n    },\n    \"no_cash\": false,/*营销经费。枚举值：true：免充值 false：预充值\n1、免充值：制券方无需提前充值资金，用户核销代金券时，直接从订单原价中扣除优惠减价金额，最终只将用户实际支付的金额结算给核销商户，商户实收少于订单原价。\n2、预充值：制券方需将优惠预算提前充值到微信支付商户可用余额中，用户核销代金券时，系统从制券方商户可用余额中扣除优惠减价部分对应的资金，连同用户实际支付的资金，一并结算给核销商户，不影响实收。 */\n    \"stock_type\": \"NORMAL\", ///批次类型，仅支持：NORMAL：固定面额满减券批次\n    \"out_request_no\": \"TencentCouponStocks0001\" ///商户创建批次凭据号（格式：商户id+日期+流水号），可包含英文字母，数字，|，_，*，-等内容，不允许出现其他不合法符号，商户侧需保持商户单据号全局唯一。\n    }",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/coupon-stocks",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"coupon-stocks"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"stock_id\": \"98065001\",///微信为每个代金券批次分配的唯一ID。\n  \"create_time\": \"2022-11-11T00:00:01+08:00\" \n  /* 创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC 8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。\n示例值：2015-05-20T13:29:35.+08:00 */\n}"
+								}
+							]
+						},
+						{
+							"name": "激活代金券批次",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_3.shtml\n   接口说明：制券成功后，通过调用此接口激活批次，如果是预充值代金券，激活时会从商户运营账户余额中锁定本批次的营销资金，运营账户余额不足则无法激活。*/\n{\n  \"stock_creator_mchid\":\"{{mchid}}\" ///批次创建方商户号\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要激活的代金券批次ID}}/start",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"{{此处替换为要激活的代金券批次ID}}",
+										"start"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_3.shtml\n   接口说明：制券成功后，通过调用此接口激活批次，如果是预充值代金券，激活时会从商户运营账户余额中锁定本批次的营销资金，运营账户余额不足则无法激活。*/\n{\n  \"stock_creator_mchid\":\"{{mchid}}\" ///批次创建方商户号\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要激活的代金券批次ID}}/start",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"{{此处替换为要激活的代金券批次ID}}",
+												"start"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"stock_id\": \"9865000\", ///微信为每个代金券批次分配的唯一id。\n    \"start_time\": \"2022-11-11T11:11:11+08:00\"\n    /* 生效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC 8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。\n示例值：2015-05-20T13:29:35+08:00 */\n}"
+								}
+							]
+						},
+						{
+							"name": "发放代金券批次",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_2.shtml\n   接口说明：商户平台/API完成制券后，可使用发放代金券接口发券。通过调用此接口可发放指定批次给指定用户，发券场景可以是小程序、H5、APP等。\n   注意：\n1、商户可在H5活动页面、商户小程序、商户APP等自有场景内调用该接口完成发券，商户默认只允许发放本商户号（调用发券接口的商户号）创建的代金券，如需发放其他商户商户创建的代金券，请申请跨商户号发券。\n2、跨商户发券时，请求参数中除了stock_id和stock_creator_mchid为创建方提供的数据，其他的所有调用数据都由发放方提供。 */\n{\n  \"stock_id\": \"9856000\", /// 代金券批次ID，必须为代金券（全场券或单品券）批次号，不支持立减与折扣。\n  \"out_request_no\": \"89560002019101000121\", ///商户此次发放凭据号（格式：商户id+日期+流水号），可包含英文字母，数字，|，_，*，-等内容，不允许出现其他不合法符号，商户下需保持唯一。\n  \"appid\": \"{{appid}}\", /* 校验规则：\n1、该appid需要与接口传入中的openid有对应关系；\n2、该appid需要与调用接口的商户号（即请求头中的商户号）有绑定关系，若未绑定，可参考该指引完成绑定 */\n  \"stock_creator_mchid\": \"{{mchid}}\" ///批次创建方商户号，校验规则：接口传入的批次号需由stock_creator_mchid所创建。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/users/{{此处替换为你要发放的openid}}/coupons",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"users",
+										"{{此处替换为你要发放的openid}}",
+										"coupons"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_2.shtml\n   接口说明：商户平台/API完成制券后，可使用发放代金券接口发券。通过调用此接口可发放指定批次给指定用户，发券场景可以是小程序、H5、APP等。\n   注意：\n1、商户可在H5活动页面、商户小程序、商户APP等自有场景内调用该接口完成发券，商户默认只允许发放本商户号（调用发券接口的商户号）创建的代金券，如需发放其他商户商户创建的代金券，请申请跨商户号发券。\n2、跨商户发券时，请求参数中除了stock_id和stock_creator_mchid为创建方提供的数据，其他的所有调用数据都由发放方提供。 */\n{\n  \"stock_id\": \"9856000\", /// 代金券批次ID，必须为代金券（全场券或单品券）批次号，不支持立减与折扣。\n  \"out_request_no\": \"89560002019101000121\", ///商户此次发放凭据号（格式：商户id+日期+流水号），可包含英文字母，数字，|，_，*，-等内容，不允许出现其他不合法符号，商户下需保持唯一。\n  \"appid\": \"{{appid}}\", /* 校验规则：\n1、该appid需要与接口传入中的openid有对应关系；\n2、该appid需要与调用接口的商户号（即请求头中的商户号）有绑定关系，若未绑定，可参考该指引完成绑定 */\n  \"stock_creator_mchid\": \"{{mchid}}\" ///批次创建方商户号，校验规则：接口传入的批次号需由stock_creator_mchid所创建。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/users/{{此处替换为你要发放的openid}}/coupons",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"users",
+												"{{此处替换为你要发放的openid}}",
+												"coupons"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"coupon_id\": \"9867041\" ///微信为代金券分配的唯一sid。\n}"
+								}
+							]
+						},
+						{
+							"name": "暂停代金券批次",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_13.shtml\n   接口说明：通过此接口可暂停指定代金券批次。暂停后，该代金券批次暂停发放，用户无法通过任何渠道再领取该批次的券。 */\n{\n  \"stock_creator_mchid\":\"{{mchid}}\" ///批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要暂停的代金券批次id}}/pause",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"{{替换为你要暂停的代金券批次id}}",
+										"pause"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_13.shtml\n   接口说明：通过此接口可暂停指定代金券批次。暂停后，该代金券批次暂停发放，用户无法通过任何渠道再领取该批次的券。 */\n{\n  \"stock_creator_mchid\":\"{{mchid}}\" ///批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要暂停的代金券批次id}}/pause",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"{{替换为你要暂停的代金券批次id}}",
+												"pause"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"stock_id\": \"8965000\", ///暂停的微信支付代金券批次ID\n  \"pause_time\": \"2022-11-11T11:22:35+08:00\"\n  /* 暂停时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC 8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。\n示例值：2015-05-20T13:29:35+08:00 */\n}"
+								}
+							]
+						},
+						{
+							"name": "重启代金券批次",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_14.shtml\n   接口说明：通过此接口可重启指定代金券批次。重启后，该代金券批次可以再次发放。 */\n{\n  \"stock_creator_mchid\":\"{{mchid}}\" ///批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要重启的代金券批次id}}/restart",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"{{替换为你要重启的代金券批次id}}",
+										"restart"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_14.shtml\n   接口说明：通过此接口可重启指定代金券批次。重启后，该代金券批次可以再次发放。 */\n{\n  \"stock_creator_mchid\":\"{{mchid}}\" ///批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要重启的代金券批次id}}/restart",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"{{替换为你要重启的代金券批次id}}",
+												"restart"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"stock_id\": \"8965000\",///重启的微信支付代金券批次ID\n  \"start_time\": \"2022-11-11T22:22:22+08:00\"\n  /*生效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC 8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。\n示例值：2015-05-20T13:29:35+08:00 */\n}"
+								}
+							]
+						},
+						{
+							"name": "条件查询批次列表",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "页码从0开始，默认第0页"
+										},
+										{
+											"key": "limit",
+											"value": "10",
+											"description": "分页大小，最大10"
+										},
+										{
+											"key": "stock_creator_mchid",
+											"value": "9856888",
+											"description": "批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。"
+										},
+										{
+											"key": "create_start_time",
+											"value": "2015-05-20T13%3A29%3A35%2B08%3A00",
+											"description": "起始创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE,校验规则：get请求，参数在 url中，需要进行 url 编码传递"
+										},
+										{
+											"key": "create_end_time",
+											"value": "2015-05-20T19%3A29%3A35%2B08%3A00",
+											"description": "终止创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE,校验规则：get请求，参数在 url中，需要进行 url 编码传递"
+										},
+										{
+											"key": "status",
+											"value": "running",
+											"description": "批次状态，枚举值：\nunactivated：未激活\naudit：审核中\nrunning：运行中\nstoped：已停止\npaused：暂停发放"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks"
+											],
+											"query": [
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "页码从0开始，默认第0页"
+												},
+												{
+													"key": "limit",
+													"value": "10",
+													"description": "分页大小，最大10"
+												},
+												{
+													"key": "stock_creator_mchid",
+													"value": "9856888",
+													"description": "批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。"
+												},
+												{
+													"key": "create_start_time",
+													"value": "2015-05-20T13%3A29%3A35%2B08%3A00",
+													"description": "起始创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE,校验规则：get请求，参数在 url中，需要进行 url 编码传递"
+												},
+												{
+													"key": "create_end_time",
+													"value": "2015-05-20T19%3A29%3A35%2B08%3A00",
+													"description": "终止创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE,校验规则：get请求，参数在 url中，需要进行 url 编码传递"
+												},
+												{
+													"key": "status",
+													"value": "running",
+													"description": "批次状态，枚举值：\nunactivated：未激活\naudit：审核中\nrunning：运行中\nstoped：已停止\npaused：暂停发放"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/// 返回字段说明看接口文档https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_4.shtml\n{\n\t\"total_count\": 10,\n\t\"data\": [{\n\t\t\"stock_id\": \"9836588\",\n\t\t\"stock_creator_mchid\": \"123456\",\n\t\t\"stock_name\": \"微信支付批次\",\n\t\t\"status\": \"paused\",\n\t\t\"create_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\"description\": \"微信支付营销\",\n\t\t\"stock_use_rule\": {\n\t\t\t\"max_coupons\": 100,\n\t\t\t\"max_amount\": 5000,\n\t\t\t\"max_amount_by_day\": 400,\n\t\t\t\"fixed_normal_coupon\": {\n\t\t\t\t\"coupon_amount\": 100,\n\t\t\t\t\"transaction_minimum\": 100\n\t\t\t},\n\t\t\t\"max_coupons_per_user\": 3,\n\t\t\t\"trade_type\":  [\"OTHER\",\"APPPAY\"]\n\t\t},\n\t\t\"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\"distributed_coupons\": 100,\n\t\t\"no_cash\": true,\n\t\t\"singleitem \": true,\n\t\t\"stock_type\": \"NORMAL\"\n\t}],\n\t\"limit\": 8,\n\t\"offset\": 1\n}"
+								}
+							]
+						},
+						{
+							"name": "查询批次详情",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要查询的代金券批次ID}}?stock_creator_mchid=123456",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"{{此处替换为要查询的代金券批次ID}}"
+									],
+									"query": [
+										{
+											"key": "stock_creator_mchid",
+											"value": "123456",
+											"description": "批次创建时的商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要查询的代金券批次ID}}?stock_creator_mchid=123456",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"{{此处替换为要查询的代金券批次ID}}"
+											],
+											"query": [
+												{
+													"key": "stock_creator_mchid",
+													"value": "123456",
+													"description": "批次创建时的商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建。"
+												}
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/// 字段参数说明请看文档 https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_5.shtml\n{\n  \"stock_id\": \"9836588\",\n  \"stock_creator_mchid\": \"123456\",\n  \"stock_name\": \"微信支付批次\",\n  \"status\": \"paused\",\n  \"create_time\": \"2015-05-20T13:29:35+08:00\",\n  \"description\": \"微信支付营销\",\n  \"stock_use_rule\": {\n    \"max_coupons\": 100,\n    \"max_amount\": 5000,\n    \"max_amount_by_day\": 400,\n\t\"max_coupons_per_user\": 3,\n    \"trade_type\":  [\"OTHER\",\"APPPAY\"]\n  },\n  \"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n  \"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n  \"distributed_coupons\": 100,\n  \"no_cash\": true,\n  \"cut_to_message\": {\n    \"single_price_max\": 100,\n    \"cut_to_price\": 5000\n  },\n  \"singleitem\": true,\n  \"stock_type\": \"NORMAL\"\n}"
+								}
+							]
+						},
+						{
+							"name": "查询代金券详情",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/users/{{openid}}/coupons/{{此处替换为要查询的代金券id}}?appid=wx233544546545989",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"users",
+										"{{openid}}",
+										"coupons",
+										"{{此处替换为要查询的代金券id}}"
+									],
+									"query": [
+										{
+											"key": "appid",
+											"value": "wx233544546545989",
+											"description": "校验规则：\n1、该appid需要与接口传入中的openid有对应关系；\n2、该appid需要与调用接口的商户号（即请求头中的商户号）有绑定关系，若未绑定，可参考该指引完成绑定 "
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/users/{{openid}}/coupons/{{此处替换为要查询的代金券id}}?appid={{appid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"users",
+												"{{openid}}",
+												"coupons",
+												"{{此处替换为要查询的代金券id}}"
+											],
+											"query": [
+												{
+													"key": "appid",
+													"value": "{{appid}}",
+													"description": "校验规则：\n1、该appid需要与接口传入中的openid有对应关系；\n2、该appid需要与调用接口的商户号（即请求头中的商户号）有绑定关系，若未绑定，可参考该指引完成绑定 "
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/// 字段参数说明看 https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_6.shtml\n{\n  \"stock_creator_mchid\": \"9800064\",\n  \"stock_id\": \"9865888\",\n  \"coupon_id\": \"98674556\",\n  \"cut_to_message\": {\n    \"single_price_max\": 100,\n    \"cut_to_price\":100\n  },\n  \"coupon_name\": \"微信支付代金券\",\n  \"status\": \"EXPIRED\",\n  \"description\": \"微信支付营销\",\n  \"create_time\": \"2015-05-20T13:29:35+08:00\",\n  \"coupon_type\": \"CUT_TO\",\n  \"no_cash\": true,\n  \"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n  \"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n  \"singleitem\": true,\n  \"normal_coupon_information\": {\n    \"coupon_amount\": 100,\n    \"transaction_minimum\": 100\n  }\n\n}"
+								}
+							]
+						},
+						{
+							"name": "查询代金券可用商户",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/merchants?offset=0&limit=10&stock_creator_mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"9865000",
+										"merchants"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "分页页码，最大1000，校验规则：分页页码必须为0。"
+										},
+										{
+											"key": "limit",
+											"value": "10",
+											"description": "分页大小，最大50"
+										},
+										{
+											"key": "stock_creator_mchid",
+											"value": "{{mchid}}",
+											"description": "批次创建方商户号，校验规则：接口传入的批次号需由stock_creator_mchid所创建。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/merchants?offset=0&limit=10&stock_creator_mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"9865000",
+												"merchants"
+											],
+											"query": [
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "分页页码，最大1000，校验规则：分页页码必须为0。"
+												},
+												{
+													"key": "limit",
+													"value": "10",
+													"description": "分页大小，最大50"
+												},
+												{
+													"key": "stock_creator_mchid",
+													"value": "{{mchid}}",
+													"description": "批次创建方商户号，校验规则：接口传入的批次号需由stock_creator_mchid所创建。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"data\": [\n        \"2480248941\" ///可用商户列表 特殊规则：单个商户号的字符长度为【1，20】,条目个数限制为【1，50】。\n    ],\n    \"limit\": 5, ///分页大小\n    \"offset\": 0, ///分页页码\n    \"stock_id\": \"15019035\", ///微信支付代金券批次号\n    \"total_count\": 1  ///可用商户总数量。\n}"
+								}
+							]
+						},
+						{
+							"name": "查询代金券可用单品",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/items?offset=10&limit=10&stock_creator_mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"9865000",
+										"items"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "10",
+											"description": "分页页码，最大500"
+										},
+										{
+											"key": "limit",
+											"value": "10",
+											"description": "分页大小，最大100"
+										},
+										{
+											"key": "stock_creator_mchid",
+											"value": "{{mchid}}",
+											"description": "批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/items?offset=10&limit=10&stock_creator_mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"9865000",
+												"items"
+											],
+											"query": [
+												{
+													"key": "offset",
+													"value": "10",
+													"description": "分页页码，最大500"
+												},
+												{
+													"key": "limit",
+													"value": "10",
+													"description": "分页大小，最大100"
+												},
+												{
+													"key": "stock_creator_mchid",
+													"value": "{{mchid}}",
+													"description": "批次创建方商户号,校验规则：接口传入的批次号需由stock_creator_mchid所创建"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"data\": [\n        \"1232001\" ///可用单品编码 特殊规则：单个商品编码的字符长度为【1，128】,条目个数限制为【1，100】。\n    ],\n    \"limit\": 5, ///分页大小\n    \"offset\": 0, ///分页页码\n    \"stock_id\": \"15019035\", ///微信支付代金券批次号\n    \"total_count\": 1 ///可用商户总数量。\n} "
+								}
+							]
+						},
+						{
+							"name": "根据商户号查用户的券",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/users/{{此处替换为要查询的用户的openid}}/coupons?appid={{appid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"users",
+										"{{此处替换为要查询的用户的openid}}",
+										"coupons"
+									],
+									"query": [
+										{
+											"key": "appid",
+											"value": "{{appid}}",
+											"description": "校验规则：\n1、该appid需要与接口传入中的openid有对应关系；\n2、该appid需要与调用接口的商户号（即请求头中的商户号）有绑定关系，若未绑定，可参考该指引完成绑定"
+										},
+										{
+											"key": "stock_id",
+											"value": "",
+											"description": "批次号，是否指定批次号查询，填写available_mchid，该字段不生效。",
+											"disabled": true
+										},
+										{
+											"key": "status",
+											"value": "",
+											"description": "代金券状态：选填creator_mchid时，\nSENDED：返回可用\nUSED：返回可用+已实扣\n选填available_mchid时，该字段不生效，仅返回 可用 状态的券。",
+											"disabled": true
+										},
+										{
+											"key": "creator_mchid",
+											"value": "",
+											"description": "批次创建方商户号（与可用商户号二选一传参）,请求参数传创建商户号返回除过期以外所有状态的用户券",
+											"disabled": true
+										},
+										{
+											"key": "available_mchid",
+											"value": "",
+											"description": "可用商户号,请求参数传核销商户号只能返回可用的代金券，实扣的与过期的无法返回",
+											"disabled": true
+										},
+										{
+											"key": "offset",
+											"value": "",
+											"description": "分页页码，默认0，填写available_mchid，该字段不生效。",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "",
+											"description": "分页大小，默认20，填写available_mchid，该字段不生效。",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/users/2323dfsdf342342/coupons?appid={{appid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"users",
+												"2323dfsdf342342",
+												"coupons"
+											],
+											"query": [
+												{
+													"key": "appid",
+													"value": "{{appid}}",
+													"description": "校验规则：\n1、该appid需要与接口传入中的openid有对应关系；\n2、该appid需要与调用接口的商户号（即请求头中的商户号）有绑定关系，若未绑定，可参考该指引完成绑定"
+												},
+												{
+													"key": "stock_id",
+													"value": null,
+													"description": "批次号，是否指定批次号查询，填写available_mchid，该字段不生效。",
+													"disabled": true
+												},
+												{
+													"key": "status",
+													"value": null,
+													"description": "代金券状态：选填creator_mchid时，\nSENDED：返回可用\nUSED：返回可用+已实扣\n选填available_mchid时，该字段不生效，仅返回 可用 状态的券。",
+													"disabled": true
+												},
+												{
+													"key": "creator_mchid",
+													"value": null,
+													"description": "批次创建方商户号（与可用商户号二选一传参）,请求参数传创建商户号返回除过期以外所有状态的用户券",
+													"disabled": true
+												},
+												{
+													"key": "available_mchid",
+													"value": null,
+													"description": "可用商户号,请求参数传核销商户号只能返回可用的代金券，实扣的与过期的无法返回",
+													"disabled": true
+												},
+												{
+													"key": "offset",
+													"value": null,
+													"description": "分页页码，默认0，填写available_mchid，该字段不生效。",
+													"disabled": true
+												},
+												{
+													"key": "limit",
+													"value": null,
+													"description": "分页大小，默认20，填写available_mchid，该字段不生效。",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/// 字段参数说明看文档 https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_9.shtml\n{\n\t\"data\": [{\n\t\t\"stock_creator_mchid\": \"9800064\",\n\t\t\"stock_id\": \"9865888\",\n\t\t\"coupon_id\": \"98674556\",\n\t\t\"cut_to_message\": {\n\t\t\t\"single_price_max\": 100,\n\t\t\t\"cut_to_price\":100\n\t\t},\n\t\t\"coupon_name\": \"微信支付代金券\",\n\t\t\"status\": \"SENDED\",\n\t\t\"description\": \"微信支付营销\",\n\t\t\"create_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\"coupon_type\": \"CUT_TO\",\n\t\t\"no_cash\": true,\n\t\t\"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\"singleitem\": true,\n\t\t\"normal_coupon_information\": {\n\t\t\t\"coupon_amount\": 100,\n\t\t\t\"transaction_minimum\": 100\n\t\t},\n\t\t\"consume_information\": {\n\t\t\t\"consume_time\": \"2015-05-20T13:29:35+08:00\",\n\t\t\t\"consume_mchid\": \"9856081\",\n\t\t\t\"transaction_id\": \"2345234523\",\n\t\t\t\"goods_detail\": [{\n\t\t\t\t\"goods_id\": \"a_goods1\",\n\t\t\t\t\"quantity\": 7,\n\t\t\t\t\"price\": 1,\n\t\t\t\t\"discount_amount\": 4\n\t\t\t}]\n\t\t}\n\t}],\n    \"total_count\": 100,\n\t\"limit\": 10,\n    \"offset\": 10\n}"
+								}
+							]
+						},
+						{
+							"name": "下载批次核销明细",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/use-flow",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"{stock_id}",
+										"use-flow"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/use-flow",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"{stock_id}",
+												"use-flow"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "下载批次退款明细",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/refund-flow",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"stocks",
+										"{stock_id}",
+										"refund-flow"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/refund-flow",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"stocks",
+												"{stock_id}",
+												"refund-flow"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n\t\"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\t\n\t\"hash_type\": \"SHA1\", ///哈希类型\t\n\t\"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\n}"
+								}
+							]
+						},
+						{
+							"name": "设置消息通知地址",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"mchid\": \"{{mchid}}\", ///校验规则：该商户号必须为创建商户号进行配置\n  \"notify_url\": \"https://pay.weixin.qq.com\"\n  /* 付通知商户url地址。\n校验规则：\n1、notify_url必须为https\n2、地址要是一个可访问的地址\n3、不能携带参数。示例： “https://pay.weixin.qq.com/wxpay/pay.action” */\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/favor/callbacks",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"favor",
+										"callbacks"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"mchid\": \"9856888\", ///校验规则：该商户号必须为创建商户号进行配置\n  \"notify_url\": \"https://pay.weixin.qq.com\"\n  /* 付通知商户url地址。\n校验规则：\n1、notify_url必须为https\n2、地址要是一个可访问的地址\n3、不能携带参数。示例： “https://pay.weixin.qq.com/wxpay/pay.action” */\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/favor/callbacks",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"favor",
+												"callbacks"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"notify_url\": \"https://pay.weixin.qq.com\", ///通知地址\n  \"update_time\": \"2015-05-20T13:29:35+08:00\"\n  /* 修改时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，yyyy-MM-DD表示年月日，T出现在字符串中，表示time元素的开头，HH:mm:ss表示时分秒，TIMEZONE表示时区（+08:00表示东八区时间，领先UTC 8小时，即北京时间）。例如：2015-05-20T13:29:35+08:00表示，北京时间2015年5月20日 13点29分35秒。\n示例值：2015-05-20T13:29:35+08:00 */\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "商家券",
+					"item": [
+						{
+							"name": "创建商家券",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_1.shtml\n   接口说明：商户可以通过该接口创建商家券。微信支付生成商家券批次后并返回商家券批次号给到商户，商户可调用发券接口【小程序发券】、【H5发券】发放该批次商家券。\n   注意：示例参数仅供参考，测试时请根据自己实际制券需求进行增加、修改、删除参数 */\n{\n  \"stock_name\":\"1212活动券\",///商家券批次名称，字数上限为21个，一个中文汉字/英文字母/数字均占用一个字数。\n  \"belong_merchant\":\"{{mchid}}\",///批次归属于哪个商户。注：普通直连模式，该参数为直连商户号\n  \"comment\": \"1212活动使用\",///批次备注，仅配置商户可见，用于自定义信息。字数上限为20个，一个中文汉字/英文字母/数字均占用一个字数。\n  \"goods_name\": \"仅限定制商品使用\",///适用商品范围，用来描述批次在哪些商品可用，会显示在微信卡包中。字数上限为15个，一个中文汉字/英文字母/数字均占用一个字数。\n  \"stock_type\": \"NORMAL\", ///批次类型 NORMAL：固定面额满减券批次 DISCOUNT：折扣券批次 EXCHANGE：换购券批次\n  \"coupon_use_rule\": {\n    \"coupon_available_time\": {\n      \"available_begin_time\": \"2022-12-01T00:00:01+08:00\", ///批次开始时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，注意：商家券有效期最长为1年。\n      \"available_end_time\": \"2022-12-30T00:00:01+08:00\", ///批次结束时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE，注意：商家券有效期最长为1年。\n      \"available_day_after_receive\": 3, ///日期区间内，券生效后x天内有效。例如生效当天内有效填1，生效后2天内有效填2，以此类推。注意，用户在有效期开始前领取商家券，则从有效期第1天开始计算天数，用户在有效期内领取商家券，则从领取当天开始计算天数，无论用户何时领取商家券，商家券在活动有效期结束后均不可用。可配合wait_days_after_receive一同填写，也可单独填写。单独填写时，有效期内领券后立即生效，生效后x天内有效。\n      \"wait_days_after_receive\":7 ///日期区间内，用户领券后需等待x天开始生效。例如领券后当天开始生效则无需填写，领券后第2天开始生效填1，以此类推。用户在有效期开始前领取商家券，则从有效期第1天开始计算天数，用户在有效期内领取商家券，则从领取当天开始计算天数。无论用户何时领取商家券，商家券在活动有效期结束后均不可用。需配合available_day_after_receive一同填写，不可单独填写。注：最大不能超过30天\n    },\n    \"fixed_normal_coupon\": {\n      \"discount_amount\": 500, ///优惠金额，单位：分。特殊规则：取值范围 1 ≤ value ≤ 10000000\n      \"transaction_minimum\": 1000 ///消费门槛，单位：分。特殊规则：取值范围 1 ≤ value ≤ 10000000\n    },\n    \"use_method\": \"OFF_LINE\"///核销方式，枚举值：OFF_LINE：线下滴码核销，点击券“立即使用”跳转展示券二维码详情。MINI_PROGRAMS：线上小程序核销，点击券“立即使用”跳转至配置的商家小程序（需要添加小程序appid和path）。 PAYMENT_CODE：微信支付付款码核销，点击券“立即使用”跳转至微信支付钱包付款码。 SELF_CONSUME：用户自助核销，点击券“立即使用”跳转至用户自助操作核销界面（当前暂不支持用户自助核销）。\n  },\n  \"stock_send_rule\": {\n    \"max_coupons\": 10, ///批次最大可发放个数限制，特殊规则：取值范围 1 ≤ value ≤ 1000000000\n    \"max_coupons_per_user\": 5,///用户最大可领张数，每个用户最多100张券 。\n    \"max_coupons_by_day\": 10, ///单天发放上限个数（stock_type为DISCOUNT或EXCHANGE时可传入此字段控制单天发放上限）。特殊规则：取值范围 1 ≤ value ≤ 1000000000\n    \"natural_person_limit\": false, ///是否开启自然人限制，不填默认否，枚举值：true：是 false：否，注：自然人防刷即同证件号下的所有账户合并计算的限领次数（限领次数指的是参数字段“用户最大领取个数”填写的值）\n    \"prevent_api_abuse\": false, ///可疑账号拦截，不填默认否，枚举值：true：是 false：否 开启后拦截用户如：黑灰产账号\n    \"transferable\": false,///是否允许转赠，不填默认否，枚举值：true：是 false：否 注意：该字段暂未开放\n    \"shareable\": false ///是否允许分享链接，不填默认否，枚举值：true：是 false：否 注意：该字段暂未开放\n  },\n  \"out_request_no\": \"100002022121212121200012\",///商户创建批次凭据号（建议格式：商户id+日期+流水号），商户侧需保持唯一性。\n  \"display_pattern_info\": {\n    \"description\": \"仅限深圳门店可用\", ///使用须知：用于说明详细的活动规则，会展示在代金券详情页。\n    \"merchant_name\": \"tencent\", ///不支持商户自定义。若券归属商户号有认证品牌，系统将自动拉取认证品牌号下的品牌名称；若券归属商户号不在认证品牌下，则拉取本商户号的商户简称。展示上限12个字符。\n    \"background_color\": \"Color020\" ///券的背景颜色，可设置10种颜色，色值请参考卡券背景颜色图。颜色取值为颜色图中的颜色名称。\n  },\n  \"coupon_code_mode\": \"WECHATPAY_MODE\" \n  /* 券code模式\t枚举值：\nWECHATPAY_MODE：系统分配券code。（固定22位纯数字）\nMERCHANT_API：商户发放时接口指定券code。\nMERCHANT_UPLOAD：商户上传自定义code，发券时系统随机选取上传的券code。\n特殊规则：\n1、券code模式为WECHATPAY_MODE时，是微信自动分配券code，商户不需要预存code；适用于多种场景\n2、券code模式为MERCHANT_API时，无需调用上传预存code接口，调用发券接口时需指定券code；更多用在商家自有流量场景（例如：商家自有小程序、H5网页等）\n3、券code模式为MERCHANT_UPLOAD，需要调用上传预存code接口上传code，调用发券接口时无需指定code；更多适用在微信支付平台流量场景（例如：支付有礼、支付有优惠等） */\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"stocks"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "查询商家券详情",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要查询的商家去批次ID}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"stocks",
+										"{{此处替换为要查询的商家去批次ID}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要查询的商家去批次ID}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"stocks",
+												"{{此处替换为要查询的商家去批次ID}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 因每张券制券参数不同，此处示例仅作参考，参数说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_2.shtml */\n{\n  \"stock_name\": \"8月1日活动券\",\n  \"belong_merchant\": \"10000022\",\n  \"comment\": \"xxx店使用\",\n  \"goods_name\": \"xxx商品使用\",\n  \"stock_type\": \"NORMAL\",\n  \"coupon_use_rule\": {\n    \"coupon_available_time\": {\n      \"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n      \"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n      \"available_day_after_receive\": 3,\n      \"available_week\": {\n        \"week_day\": [\n          1,\n          2\n        ],\n        \"available_day_time\": [\n          {\n            \"begin_time\": 3600,\n            \"end_time\": 86399\n          }\n        ]\n      },\n      \"irregulary_avaliable_time\": [\n        {\n          \"begin_time\": \"2015-05-20T13:29:35+08:00\",\n          \"end_time\": \"2015-05-20T13:29:35+08:00\"\n        }\n      ]\n    },\n    \"fixed_normal_coupon\": {\n      \"discount_amount\": 5,\n      \"transaction_minimum\": 100\n    },\n    \"use_method\": \"OFF_LINE\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"stock_send_rule\": {\n    \"max_amount\": 100000,\n    \"max_coupons\": 100,\n    \"max_coupons_per_user\": 5,\n    \"max_amount_by_day\": 1000,\n    \"max_coupons_by_day\": 100,\n    \"natural_person_limit\": false,\n    \"prevent_api_abuse\": false,\n    \"transferable\": false,\n    \"shareable\": false\n  },\n  \"custom_entrance\": {\n    \"mini_programs_info\": {\n      \"mini_programs_appid\": \"wx234545656765876\",\n      \"mini_programs_path\": \"/path/index/index\",\n      \"entrance_words\": \"欢迎选购\",\n      \"guiding_words\": \"获取更多优惠\"\n    },\n    \"appid\": \"wx324345hgfhfghfg\",\n    \"hall_id\": \"233455656\",\n    \"store_id\": \"233554655\"\n  },\n  \"display_pattern_info\": {\n    \"description\": \"xxx门店可用\",\n    \"merchant_logo_url\": \"https://xxx\",\n    \"merchant_name\": \"微信支付\",\n    \"background_color\": \"Color020\",\n    \"coupon_image_url\": \"https://qpic.cn/xxx\",\n        \"finder_info\": {\n          \"finder_id\": \"sph6Rngt2T4RlUf\",\n          \"finder_video_cover_image_url\": \"https://wxpaylogo.qpic.cn/xxx\",\n          \"finder_video_id\": \"export/UzFfAgtgekIEAQAAAAAAb4MgnPInmAAAAAstQy6ubaLX4KHWvLEZgBPEwIEgVnk9HIP-zNPgMJofG6tpdGPJNg_ojtEjoT94\"\n        }\n  },\n  \"stock_state\": \"RUNNING\",\n  \"coupon_code_mode\": \"MERCHANT_UPLOAD\",\n  \"stock_id\": \"1212\",\n  \"coupon_code_count\": {\n    \"total_count\": 100,\n    \"available_count\": 50\n  }\n}"
+								}
+							]
+						},
+						{
+							"name": "核销用户券",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "///接口说明：在用户满足优惠门槛后，商户可通过该接口核销用户微信卡包中具体某一张商家券。\n///接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_3.shtml\n{\n  \"coupon_code\": \"sxxe34343434\", ///券的唯一标识\n  \"stock_id\": \"100088\", ///信为每个商家券批次分配的唯一ID，当你在创建商家券接口中的coupon_code_mode参数传值为MERCHANT_API或者MERCHANT_UPLOAD时，则核销接口中该字段必传，否则该字段可不传\n  \"appid\": \"{{appid}}\",\n  \"use_time\": \"2015-05-20T13:29:35+08:00\",///商户请求核销用户券的时间。 遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"use_request_no\": \"1002600620019090123143254435\",///核销请求单据号，每次核销请求的唯一标识，商户需保证唯一。\n  \"openid\": \"xsd3434454567676\" ///用户的唯一标识，做安全校验使用，非必填。校验规则：传入的openid得是调用方商户号（即请求头里面的商户号）有绑定关系的APPID获取的openid或传入的openid得是归属商户号有绑定关系的APPID获取的openid。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/use",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"coupons",
+										"use"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "///接口说明：在用户满足优惠门槛后，商户可通过该接口核销用户微信卡包中具体某一张商家券。\n///接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_3.shtml\n{\n  \"coupon_code\": \"sxxe34343434\", ///券的唯一标识\n  \"stock_id\": \"100088\", ///信为每个商家券批次分配的唯一ID，当你在创建商家券接口中的coupon_code_mode参数传值为MERCHANT_API或者MERCHANT_UPLOAD时，则核销接口中该字段必传，否则该字段可不传\n  \"appid\": \"{{appid}}\",\n  \"use_time\": \"2015-05-20T13:29:35+08:00\",///商户请求核销用户券的时间。 遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"use_request_no\": \"1002600620019090123143254435\",///核销请求单据号，每次核销请求的唯一标识，商户需保证唯一。\n  \"openid\": \"xsd3434454567676\" ///用户的唯一标识，做安全校验使用，非必填。校验规则：传入的openid得是调用方商户号（即请求头里面的商户号）有绑定关系的APPID获取的openid或传入的openid得是归属商户号有绑定关系的APPID获取的openid。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/use",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"coupons",
+												"use"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"stock_id\": \"100088\",///商家券批次id\n  \"openid\": \"dsadas34345454545\",///核销用户在APPID下的唯一身份标识\n  \"wechatpay_use_time\": \"2022-12-12T12:12:12+08:00\" ///系统成功核销券的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "根据过滤条件查询用户券",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons?appid=wx233544546545989&stock_id=9865000&coupon_state=USED&creator_merchant=1000000001&offset=0&limit=20",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"users",
+										"{{openid}}",
+										"coupons"
+									],
+									"query": [
+										{
+											"key": "appid",
+											"value": "wx233544546545989",
+											"description": "校验规则：传入的APPID得是与调用方商户号（即请求头里面的商户号）有绑定关系的APPID 或 传入的APPID得是归属商户号有绑定关系的APPID"
+										},
+										{
+											"key": "stock_id",
+											"value": "9865000",
+											"description": "批次ID，是否指定批次号查询"
+										},
+										{
+											"key": "coupon_state",
+											"value": "USED",
+											"description": "券状态，枚举值：SENDED：可用；USED：已核销；EXPIRED：已过期"
+										},
+										{
+											"key": "creator_merchant",
+											"value": "1000000001",
+											"description": "校验规则：当调用方商户号（即请求头中的商户号）为创建批次方商户号时，该参数必传"
+										},
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "分页页码"
+										},
+										{
+											"key": "limit",
+											"value": "20",
+											"description": "分页大小"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons?appid=wx233544546545989&stock_id=9865000&coupon_state=USED&creator_merchant=1000000001&offset=0&limit=20",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"users",
+												"{{openid}}",
+												"coupons"
+											],
+											"query": [
+												{
+													"key": "appid",
+													"value": "wx233544546545989",
+													"description": "校验规则：传入的APPID得是与调用方商户号（即请求头里面的商户号）有绑定关系的APPID 或 传入的APPID得是归属商户号有绑定关系的APPID"
+												},
+												{
+													"key": "stock_id",
+													"value": "9865000",
+													"description": "批次ID，是否指定批次号查询"
+												},
+												{
+													"key": "coupon_state",
+													"value": "USED",
+													"description": "券状态，枚举值：SENDED：可用；USED：已核销；EXPIRED：已过期"
+												},
+												{
+													"key": "creator_merchant",
+													"value": "1000000001",
+													"description": "校验规则：当调用方商户号（即请求头中的商户号）为创建批次方商户号时，该参数必传"
+												},
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "分页页码"
+												},
+												{
+													"key": "limit",
+													"value": "20",
+													"description": "分页大小"
+												}
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 因每张券制券参数不同，此处示例仅作参考，参数说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_4.shtml\n   注意：为提升API性能，返回参数中“结果集>样式信息>使用须知（description）”字段内容将不再返回，即查询结果不再返回使用须知，改动将于2020年7月8日12:00生效。如您业务中需要使用该字段，建议使用“查询用户单张券详情API” */\n{\n  \"data\": [\n    {\n      \"belong_merchant\": \"100000222\",\n      \"stock_name\": \"商家券\",\n      \"comment\": \"xxx可用\",\n      \"goods_name\": \"xxx商品可用\",\n      \"stock_type\": \"NORMAL\",\n      \"transferable\": false,\n      \"shareable\": \"false\",\n      \"coupon_state\": \"SENDED\",\n      \"display_pattern_info\": {\n        \"merchant_logo_url\": \"https://xxx\",\n        \"merchant_name\": \"微信支付\",\n        \"background_color\": \"Color020\",\n        \"coupon_image_url\": \"https://qpic.cn/xxx\",\n        \"finder_info\": {\n              \"finder_id\": \"sph6Rngt2T4RlUf\",\n              \"finder_video_cover_image_url\": \"https://wxpaylogo.qpic.cn/xxx\",\n              \"finder_video_id\": \"export/UzFfAgtgekIEAQAAAAAAb4MgnPInmAAAAAstQy6ubaLX4KHWvLEZgBPEwIEgVnk9HIP-zNPgMJofG6tpdGPJNg_ojtEjoT94\"\n            }\n      },\n      \"coupon_use_rule\": {\n        \"coupon_available_time\": {\n          \"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n          \"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n          \"available_day_after_receive\": 3,\n          \"available_week\": {\n            \"week_day\": [\n              \"1\",\n              \"2\"\n            ],\n            \"available_day_time\": [\n              {\n                \"begin_time\": 3600,\n                \"end_time\": 86399\n              }\n            ]\n          },\n          \"irregulary_avaliable_time\": [\n            {\n              \"begin_time\": \"2015-05-20T13:29:35+08:00\",\n              \"end_time\": \"2015-05-20T13:29:35+08:00\"\n            }\n          ]\n        },\n        \"fixed_normal_coupon\": {\n          \"discount_amount\": 5,\n          \"transaction_minimum\": 100\n        },\n        \"use_method\": \"OFF_LINE\",\n        \"mini_programs_appid\": \"wx23232232323\",\n        \"mini_programs_path\": \"/path/index/index\"\n      },\n      \"custom_entrance\": {\n        \"mini_programs_info\": {\n          \"mini_programs_appid\": \"wx234545656765876\",\n          \"mini_programs_path\": \"/path/index/index\",\n          \"entrance_words\": \"欢迎选购\",\n          \"guiding_words\": \"获取更多优惠\"\n        },\n        \"appid\": \"wx324345hgfhfghfg\",\n        \"hall_id\": \"233455656\",\n        \"store_id\": \"233554655\"\n      },\n      \"coupon_code\": \"123446565767\",\n      \"stock_id\": \"1002323\",\n      \"available_start_time\": \"2019-12-30T13:29:35+08:00\",\n      \"expire_time\": \"2019-12-31T13:29:35+08:00\",\n      \"receive_time\": \"2019-12-30T13:29:35+08:00\",\n\t  \"send_request_no\": \"MCHSEND202003101234\",\n\t  \"use_request_no\": \"MCHSEND202003101234\",\n\t  \"use_time\": \"2019-12-30T13:29:35+08:00\"\n    }\n  ],\n  \"total_count\": 100,\n  \"limit\": 10,\n  \"offset\": 1\n}\n   "
+								}
+							]
+						},
+						{
+							"name": "查询用户单张券详情",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons/{{此处替换为要查询的商家券code}}/appids/{{appid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"users",
+										"{{openid}}",
+										"coupons",
+										"{{此处替换为要查询的商家券code}}",
+										"appids",
+										"{{appid}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons/{{此处替换为要查询的商家券code}}/appids/{{appid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"users",
+												"{{openid}}",
+												"coupons",
+												"{{此处替换为要查询的商家券code}}",
+												"appids",
+												"{{appid}}"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 因每张券制券参数不同，此处示例仅作参考，参数说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_5.shtml */\n{\n  \"belong_merchant\": \"100000222\",\n  \"stock_name\": \"商家券\",\n  \"comment\": \"xxx可用\",\n  \"goods_name\": \"xxx商品可用\",\n  \"stock_type\": \"NORMAL\",\n  \"transferable\": false,\n  \"shareable\": false,\n  \"coupon_state\": \"SENDED\",\n  \"display_pattern_info\": {\n    \"description\": \"xxx门店可用\",\n    \"merchant_logo_url\": \"https://xxx\",\n    \"merchant_name\": \"微信支付\",\n    \"background_color\": \"Color020\",\n    \"coupon_image_url\": \"https://qpic.cn/xxx\",\n    \"finder_info\": {\n          \"finder_id\": \"sph6Rngt2T4RlUf\",\n          \"finder_video_cover_image_url\": \"https://wxpaylogo.qpic.cn/xxx\",\n          \"finder_video_id\": \"export/UzFfAgtgekIEAQAAAAAAb4MgnPInmAAAAAstQy6ubaLX4KHWvLEZgBPEwIEgVnk9HIP-zNPgMJofG6tpdGPJNg_ojtEjoT94\"\n        }\n  },\n  \"coupon_use_rule\": {\n    \"coupon_available_time\": {\n      \"available_begin_time\": \"2015-05-20T13:29:35+08:00\",\n      \"available_end_time\": \"2015-05-20T13:29:35+08:00\",\n      \"available_day_after_receive\": 3,\n      \"available_week\": {\n        \"week_day\": [\n          \"1\",\n          \"2\"\n        ],\n        \"available_day_time\": [\n          {\n            \"begin_time\": 3600,\n            \"end_time\": 86399\n          }\n        ]\n      },\n      \"irregulary_avaliable_time\": [\n        {\n          \"begin_time\": \"2015-05-20T13:29:35+08:00\",\n          \"end_time\": \"2015-05-20T13:29:35+08:00\"\n        }\n      ]\n    },\n    \"fixed_normal_coupon\": {\n      \"discount_amount\": 5,\n      \"transaction_minimum\": 100\n    },\n    \"use_method\": \"OFF_LINE\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"custom_entrance\": {\n    \"mini_programs_info\": {\n      \"mini_programs_appid\": \"wx234545656765876\",\n      \"mini_programs_path\": \"/path/index/index\",\n      \"entrance_words\": \"欢迎选购\",\n      \"guiding_words\": \"获取更多优惠\"\n    },\n    \"appid\": \"wx324345hgfhfghfg\",\n    \"hall_id\": \"233455656\",\n    \"store_id\": \"233554655\"\n  },\n  \"coupon_code\": \"123446565767\",\n  \"stock_id\": \"1002323\",\n  \"available_start_time\": \"2019-12-30T13:29:35+08:00\",\n  \"expire_time\": \"2019-12-31T13:29:35+08:00\",\n  \"receive_time\": \"2019-12-30T13:29:35+08:00\",\n  \"send_request_no\": \"MCHSEND202003101234\",\n  \"use_request_no\": \"MCHSEND202003101234\",\n  \"use_time\": \"2019-12-30T13:29:35+08:00\"\n}"
+								}
+							]
+						},
+						{
+							"name": "上传预存code",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_6.shtml\n   接口说明：商家券的Code码可由微信后台随机分配，同时支持商户自定义。如商家已有自己的优惠券系统，可直接使用自定义模式。即商家预先向微信支付上传券Code，当券在发放时，微信支付自动从已导入的Code中随机取值（不能指定），派发给用户。 */\n{\n  \"coupon_code_list\": [\n    \"ABC9588200\",\n    \"ABC9588201\"\n  ],\n  /* 商户上传的券code列表，code允许包含的字符有0-9、a-z、A-Z、-、_、\\、/、=、|。\n     特殊规则：单个券code长度为【1，32】，条目个数限制为【1，200】。 */\n  \"upload_request_no\": \"100002322019090134234sfdf\" \n  ///商户上传code的凭据号，商户号下需保持唯一性。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}/couponcodes",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"stocks",
+										"{stock_id}",
+										"couponcodes"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_6.shtml\n   接口说明：商家券的Code码可由微信后台随机分配，同时支持商户自定义。如商家已有自己的优惠券系统，可直接使用自定义模式。即商家预先向微信支付上传券Code，当券在发放时，微信支付自动从已导入的Code中随机取值（不能指定），派发给用户。 */\n{\n  \"coupon_code_list\": [\n    \"ABC9588200\",\n    \"ABC9588201\"\n  ],\n  /* 商户上传的券code列表，code允许包含的字符有0-9、a-z、A-Z、-、_、\\、/、=、|。\n     特殊规则：单个券code长度为【1，32】，条目个数限制为【1，200】。 */\n  \"upload_request_no\": \"100002322019090134234sfdf\" \n  ///商户上传code的凭据号，商户号下需保持唯一性。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}/couponcodes",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"stocks",
+												"{stock_id}",
+												"couponcodes"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"stock_id\": \"98065001\", ///商家券批次ID\n  \"total_count\": 500, ///本次上传操作，去重后实际上传的code数目。\n  \"success_count\": 20, ///本次上传操作上传成功个数。\n  \"success_codes\": [\n    \"MMAA12345\" ///本次新增上传成功的code信息。\n  ],\n  \"success_time\": \"2022-11-11T11:11:11+08:00\", ///上传操作完成时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"fail_count\": 10, ///本次上传操作上传失败的code数。\n  \"fail_codes\": [\n    {\n      \"coupon_code\": \"ABCD23456\", ///上传失败的券code\n      \"code\": \"LENGTH_LIMIT\", ///上传失败错误码\n      \"message\": \"长度超过最大值32位\" ///上传失败错误信息\n    }\n  ],\n  \"exist_codes\": [\n    \"ABCD2345\" ///历史已存在的code列表，本次不会重复导入。\n  ],\n  \"duplicate_codes\": [\n    \"AACC2345\" ///本次重复导入的code会被自动过滤，仅保留一个做导入，如满足要求则成功；如不满足要求，则失败；请参照报错提示修改重试。\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "设置商家券事件通知地址",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_7.shtml\n   接口说明：用于设置接收商家券相关事件通知的URL，可接收商家券相关的事件通知、包括发放通知等。需要设置接收通知的URL，并在商户平台开通营销事件推送的能力，即可接收到相关通知。 */\n{\n  \"mchid\": \"{{mchid}}\", ///微信支付商户的商户号，不填默认为调用接口商户号\n  \"notify_url\": \"https://pay.weixin.qq.com\" ///商户提供的用于接收商家券事件通知的url地址，必须支持https。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"callbacks"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_7.shtml\n   接口说明：用于设置接收商家券相关事件通知的URL，可接收商家券相关的事件通知、包括发放通知等。需要设置接收通知的URL，并在商户平台开通营销事件推送的能力，即可接收到相关通知。 */\n{\n  \"mchid\": \"{{mchid}}\", ///微信支付商户的商户号，不填默认为调用接口商户号\n  \"notify_url\": \"https://pay.weixin.qq.com\" ///商户提供的用于接收商家券事件通知的url地址，必须支持https。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"callbacks"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"update_time\": \"2022-11-11T11:11:11+08:00\", ///修改时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"notify_url\": \"https://pay.weixin.qq.com\",///设置成功用于接收商家券事件通知的url地址，需支持https。\n  \"mchid\": \"1900000000\"///配置商家券事件通知地址的商户号\n}"
+								}
+							]
+						},
+						{
+							"name": "查询商家券事件通知地址",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks?mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"callbacks"
+									],
+									"query": [
+										{
+											"key": "mchid",
+											"value": "{{mchid}}",
+											"description": "微信支付商户的商户号，不填默认查询调用方商户的通知URL。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks?mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"callbacks"
+											],
+											"query": [
+												{
+													"key": "mchid",
+													"value": "{{mchid}}",
+													"description": "微信支付商户的商户号，不填默认查询调用方商户的通知URL。"
+												}
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"notify_url\": \"https://pay.weixin.qq.com\",///设置成功用于接收商家券事件通知的url地址，需支持https。\n  \"mchid\": \"1900000000\"///配置商家券事件通知地址的商户号\n}"
+								}
+							]
+						},
+						{
+							"name": "关联订单信息",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_9.shtml\n   接口说明：将有效态（未核销）的商家券与订单信息关联，用于后续参与摇奖&返佣激励等操作的统计。 */\n{\n  \"coupon_code\" : \"12333333\",///用户已领取券的唯一标识\n  \"out_trade_no\" : \"MCH_102233445\",///商户请求支付下单时的商户订单号，欲与该商家券关联的微信支付\n  \"stock_id\" : \"100088\",///商家券批次号\n  \"out_request_no\" : \"1002600620019090123143254435\"///商户创建批次凭据号（格式：商户id+日期+流水号），商户号下需保持唯一，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/associate",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"coupons",
+										"associate"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_9.shtml\n   接口说明：将有效态（未核销）的商家券与订单信息关联，用于后续参与摇奖&返佣激励等操作的统计。 */\n{\n  \"coupon_code\" : \"12333333\",///用户已领取券的唯一标识\n  \"out_trade_no\" : \"MCH_102233445\",///商户请求支付下单时的商户订单号，欲与该商家券关联的微信支付\n  \"stock_id\" : \"100088\",///商家券批次号\n  \"out_request_no\" : \"1002600620019090123143254435\"///商户创建批次凭据号（格式：商户id+日期+流水号），商户号下需保持唯一，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/associate",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"coupons",
+												"associate"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"wechatpay_associate_time\": \"2022-11-11T11:11:11+08:00\" ///系统关联券成功的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "取消关联订单信息",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_10.shtml\n   接口说明：取消商家券与订单信息的关联关系，建议取消前调用查询接口，查到当前关联的商户单号并确认后，再进行取消操作 */\n{\n  \"coupon_code\" : \"213dsadfsa\",///用户已领取券的唯一标识\n  \"out_trade_no\" : \"MCH_102233445\",///商户请求支付下单时的商户订单号\n  \"stock_id\" : \"100088\",///商家券批次号\n  \"out_request_no\" : \"fdsafdsafdsa231321\"///商户创建批次凭据号（格式：商户id+日期+流水号），商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/disassociate",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"coupons",
+										"disassociate"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_10.shtml\n   接口说明：取消商家券与订单信息的关联关系，建议取消前调用查询接口，查到当前关联的商户单号并确认后，再进行取消操作 */\n{\n  \"coupon_code\" : \"213dsadfsa\",///用户已领取券的唯一标识\n  \"out_trade_no\" : \"MCH_102233445\",///商户请求支付下单时的商户订单号\n  \"stock_id\" : \"100088\",///商家券批次号\n  \"out_request_no\" : \"fdsafdsafdsa231321\"///商户创建批次凭据号（格式：商户id+日期+流水号），商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/disassociate",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"coupons",
+												"disassociate"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"wechatpay_disassociate_time\": \"2022-11-11T11:11:11+08:00\" ///系统成功取消商家券与订单信息关联关系的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "修改批次预算",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_11.shtml\n   接口说明：商户可以通过该接口修改批次单天发放上限数量或者批次最大发放数量 */\n{\n  \"target_max_coupons\": 3000, ///目标批次最大发放个数，注：目标批次指的是修改后的批次\n  \"current_max_coupons\": 500,///当前批次最大发放个数，当传入target_max_coupons大于0时，current_max_coupons必传 注：当前批次指的是未修改的批次\n  \"modify_budget_request_no\": \"1002600620019090123143254436\" ///修改预算请求单据号，商户号下需要保持唯一\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要修改预算的商家券批次号}}/budget",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"stocks",
+										"{{此处替换为要修改预算的商家券批次号}}",
+										"budget"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_11.shtml\n   接口说明：商户可以通过该接口修改批次单天发放上限数量或者批次最大发放数量 */\n{\n  \"target_max_coupons\": 3000, ///目标批次最大发放个数，注：目标批次指的是修改后的批次\n  \"current_max_coupons\": 500,///当前批次最大发放个数，当传入target_max_coupons大于0时，current_max_coupons必传 注：当前批次指的是未修改的批次\n  \"modify_budget_request_no\": \"1002600620019090123143254436\" ///修改预算请求单据号，商户号下需要保持唯一\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要修改预算的商家券批次号}}/budget",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"stocks",
+												"{{此处替换为要修改预算的商家券批次号}}",
+												"budget"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"max_coupons\": 3000,///修改后批次最大发放个数\n  \"max_coupons_by_day\": 500 ///修改后当前单天发放上限个数\n}"
+								}
+							]
+						},
+						{
+							"name": "修改商家券基本信息",
+							"request": {
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_12.shtml\n   接口说明：商户可以通过该接口修改商家券基本信息\n   注意：示例请求参数仅供参考，请求时需要根据自己制券时参数进行匹配，否则会报错，参数说明看接口地址链接 */\n{\n  \"custom_entrance\": {\n    \"mini_programs_info\": {\n      \"mini_programs_appid\": \"wx234545656765876\",\n      \"mini_programs_path\": \"/path/index/index\",\n      \"entrance_words\": \"欢迎选购\",\n      \"guiding_words\": \"获取更多优惠\"\n    },\n\t\"appid\": \"wx324345hgfhfghfg\",\n    \"hall_id\": \"233455656\",\n    \"code_display_mode\": \"BARCODE\"\n  },\n  \"comment\": \"活动使用\",\n  \"goods_name\": \"xxx商品使用\",\n  \"out_request_no\": \"6122352020010133287985742\",\n  \"display_pattern_info\": {\n    \"description\": \"xxx门店可用\",\n    \"background_color\": \"xxxxx\",\n    \"coupon_image_url\": \"图片cdn地址\",\n    \"finder_info\": {\n          \"finder_id\": \"sph6Rngt2T4RlUf\",\n          \"finder_video_cover_image_url\": \"https://wxpaylogo.qpic.cn/xxx\",\n          \"finder_video_id\": \"export/UzFfAgtgekIEAQAAAAAAb4MgnPInmAAAAAstQy6ubaLX4KHWvLEZgBPEwIEgVnk9HIP-zNPgMJofG6tpdGPJNg_ojtEjoT94\"\n        }\n  },\n  \"coupon_use_rule\": {\n    \"use_method\": \"OFF_LINE\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"stock_send_rule\": {\n    \"prevent_api_abuse\": false\n  },\n  \"notify_config\": {\n    \"notify_appid\": \"wx23232232323\"\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"stocks",
+										"{stock_id}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_12.shtml\n   接口说明：商户可以通过该接口修改商家券基本信息\n   注意：示例请求参数仅供参考，请求时需要根据自己制券时参数进行匹配，否则会报错，参数说明看接口地址链接 */\n{\n  \"custom_entrance\": {\n    \"mini_programs_info\": {\n      \"mini_programs_appid\": \"wx234545656765876\",\n      \"mini_programs_path\": \"/path/index/index\",\n      \"entrance_words\": \"欢迎选购\",\n      \"guiding_words\": \"获取更多优惠\"\n    },\n\t\"appid\": \"wx324345hgfhfghfg\",\n    \"hall_id\": \"233455656\",\n    \"code_display_mode\": \"BARCODE\"\n  },\n  \"comment\": \"活动使用\",\n  \"goods_name\": \"xxx商品使用\",\n  \"out_request_no\": \"6122352020010133287985742\",\n  \"display_pattern_info\": {\n    \"description\": \"xxx门店可用\",\n    \"background_color\": \"xxxxx\",\n    \"coupon_image_url\": \"图片cdn地址\",\n    \"finder_info\": {\n          \"finder_id\": \"sph6Rngt2T4RlUf\",\n          \"finder_video_cover_image_url\": \"https://wxpaylogo.qpic.cn/xxx\",\n          \"finder_video_id\": \"export/UzFfAgtgekIEAQAAAAAAb4MgnPInmAAAAAstQy6ubaLX4KHWvLEZgBPEwIEgVnk9HIP-zNPgMJofG6tpdGPJNg_ojtEjoT94\"\n        }\n  },\n  \"coupon_use_rule\": {\n    \"use_method\": \"OFF_LINE\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"stock_send_rule\": {\n    \"prevent_api_abuse\": false\n  },\n  \"notify_config\": {\n    \"notify_appid\": \"wx23232232323\"\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"stocks",
+												"{stock_id}"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "申请退券",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_13.shtml\n   接口说明：商户可以在退款之后调用退券api，调用了该接口后，券在用户卡包内正常展示，用户可在有效期内正常使用该优惠券。若券过期状态下退款，可不用调用该退券api。 */\n{\n  \"coupon_code\": \"sxxe34343434\",///要退券的券标识\n  \"stock_id\": \"1234567891\",///要退券的商家券批次号\n  \"return_request_no\": \"1002600620019090123143254436\" ///每次退券请求的唯一标识，商户号下需保证唯一\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/return",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"coupons",
+										"return"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_13.shtml\n   接口说明：商户可以在退款之后调用退券api，调用了该接口后，券在用户卡包内正常展示，用户可在有效期内正常使用该优惠券。若券过期状态下退款，可不用调用该退券api。 */\n{\n  \"coupon_code\": \"sxxe34343434\",///要退券的券标识\n  \"stock_id\": \"1234567891\",///要退券的商家券批次号\n  \"return_request_no\": \"1002600620019090123143254436\" ///每次退券请求的唯一标识，商户号下需保证唯一\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/return",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"coupons",
+												"return"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"wechatpay_return_time\": \"2022-12-12T12:12:12.120+08:00\" ///微信退券成功的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "使券失效",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_14.shtml \n   接口说明：商户可通过该接口将单张领取后未核销的券进行失效处理，券失效后无法再被核销 */\n{\n  \"coupon_code\": \"sxxe34343434\",///要作废券的code\n  \"stock_id\": \"1234567891\", ///要作废券code对应的商家券批次号\n  \"deactivate_request_no\": \"1002600620019090123143254436\", ///每次作废券请求的唯一标识，商户号下需保证唯一\n  \"deactivate_reason\": \"此券使用时间设置错误\" ///商户失效券的原因，可不传\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/deactivate",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"coupons",
+										"deactivate"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_14.shtml \n   接口说明：商户可通过该接口将单张领取后未核销的券进行失效处理，券失效后无法再被核销 */\n{\n  \"coupon_code\": \"sxxe34343434\",///要作废券的code\n  \"stock_id\": \"1234567891\", ///要作废券code对应的商家券批次号\n  \"deactivate_request_no\": \"1002600620019090123143254436\", ///每次作废券请求的唯一标识，商户号下需保证唯一\n  \"deactivate_reason\": \"此券使用时间设置错误\" ///商户失效券的原因，可不传\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/deactivate",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"coupons",
+												"deactivate"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"wechatpay_deactivate_time\": \"2022-12-12T12:12:12.120+08:00\" ///系统券成功失效的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "营销补差付款",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_16.shtml\n   接口说明：该API主要用于商户营销补贴场景，支持基于单张券进行不同商户账户间的资金补差，从而提升财务结算、资金利用效率。具体可参考https://pay.weixin.qq.com/wiki/doc/apiv3/download/%E5%95%86%E5%AE%B6%E5%88%B8%E8%A1%A5%E5%B7%AE%E4%BA%A7%E5%93%81%E6%93%8D%E4%BD%9C%E6%96%87%E6%A1%A3.pdf */\n{\n  \"stock_id\": \"128888000000001\", ///调用创建商家券API成功时返回的商家券批次ID 仅支持“满减券”，“换购券”批次不支持\n  \"coupon_code\": \"ABCD12345678\",///商家券Code，券的唯一标识，在WECHATPAY_MODE的券Code模式下，商家券Code是由微信支付生成的唯一ID；在MERCHANT_UPLOAD、MERCHANT_API的券Code模式下，商家券Code是由商户上传或指定，在批次下保证唯一\n  \"transaction_id\": \"4200000913202101152566792388\", ///要补差的微信支付下单支付成功返回的订单号\n  \"payer_merchant\": \"1900000001\", ///营销补差扣款商户号 注：补差扣款商户号 = 制券商户号 或 补差扣款商户号 = 归属商户号\n  \"payee_merchant\": \"1900000002\", ///营销补差入账商户号 注：补差入帐商户号 = 券归属商户号 或者和 券归属商户号有连锁品牌关系\n  \"amount\": 100, ///补差付款金额，单位为分，单笔订单补差金额不得超过券的优惠金额，最高补差金额为5000元 > 券的优惠金额定义：满减券：满减金额即为优惠金额 换购券：不支持\t\n  \"description\": \"20210115DESCRIPTION\",///补差付款描述，查单的时候原样带回\n  \"out_subsidy_no\": \"subsidy-abcd-12345678\" ///补差请求单号，商户侧需保证唯一性。可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"subsidy",
+										"pay-receipts"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_2_16.shtml\n   接口说明：该API主要用于商户营销补贴场景，支持基于单张券进行不同商户账户间的资金补差，从而提升财务结算、资金利用效率。具体可参考https://pay.weixin.qq.com/wiki/doc/apiv3/download/%E5%95%86%E5%AE%B6%E5%88%B8%E8%A1%A5%E5%B7%AE%E4%BA%A7%E5%93%81%E6%93%8D%E4%BD%9C%E6%96%87%E6%A1%A3.pdf */\n{\n  \"stock_id\": \"128888000000001\", ///调用创建商家券API成功时返回的商家券批次ID 仅支持“满减券”，“换购券”批次不支持\n  \"coupon_code\": \"ABCD12345678\",///商家券Code，券的唯一标识，在WECHATPAY_MODE的券Code模式下，商家券Code是由微信支付生成的唯一ID；在MERCHANT_UPLOAD、MERCHANT_API的券Code模式下，商家券Code是由商户上传或指定，在批次下保证唯一\n  \"transaction_id\": \"4200000913202101152566792388\", ///要补差的微信支付下单支付成功返回的订单号\n  \"payer_merchant\": \"1900000001\", ///营销补差扣款商户号 注：补差扣款商户号 = 制券商户号 或 补差扣款商户号 = 归属商户号\n  \"payee_merchant\": \"1900000002\", ///营销补差入账商户号 注：补差入帐商户号 = 券归属商户号 或者和 券归属商户号有连锁品牌关系\n  \"amount\": 100, ///补差付款金额，单位为分，单笔订单补差金额不得超过券的优惠金额，最高补差金额为5000元 > 券的优惠金额定义：满减券：满减金额即为优惠金额 换购券：不支持\t\n  \"description\": \"20210115DESCRIPTION\",///补差付款描述，查单的时候原样带回\n  \"out_subsidy_no\": \"subsidy-abcd-12345678\" ///补差请求单号，商户侧需保证唯一性。可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"subsidy",
+												"pay-receipts"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"subsidy_receipt_id\": \"1120200119165100000000000001\", ///补差付款唯一单号，由微信支付生成，仅在补差付款成功后有返回\n  \"stock_id\": \"128888000000001\",///补差对应的商家券批次号\n  \"coupon_code\": \"ABCD12345678\", ///补差对应的商家券Code\n  \"transaction_id\": \"4200000913202101152566792388\",///补差对应的微信支付单号\n  \"payer_merchant\": \"1900000001\",///补差扣款商户号\n  \"payee_merchant\": \"1900000002\",///补差入账商户号\n  \"amount\": 100,///补差付款金额，单位为分\n  \"description\": \"20210115DESCRIPTION\",///补差付款描述\t\n  \"status\": \"SUCCESS\", ///补差付款单据状态，枚举值ACCEPTED：受理成功 SUCCESS：补差补款成功 FAIL：补差付款失败 RETURNING：补差回退中 PARTIAL_RETURN：补差部分回退 FULL_RETURN：补差全额回退\n  \"success_time\": \"2021-01-20T10:29:35.120+08:00\",///仅在补差付款成功时，返回完成时间。遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"out_subsidy_no\": \"subsidy-abcd-12345678\",///商户发起补差请求生成的单号\n  \"create_time\": \"2021-01-20T10:29:35.120+08:00\" ///补差付款单据创建时间。遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "查询营销补差付款单详情",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts/{{此处替换为要查询的补差付款单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"busifavor",
+										"subsidy",
+										"pay-receipts",
+										"{{此处替换为要查询的补差付款单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts/{{此处替换为要查询的补差付款单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"busifavor",
+												"subsidy",
+												"pay-receipts",
+												"{{此处替换为要查询的补差付款单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"subsidy_receipt_id\": \"1120200119165100000000000001\", ///补差付款唯一单号，由微信支付生成，仅在补差付款成功后有返回\n  \"stock_id\": \"128888000000001\",///补差对应的商家券批次号\n  \"coupon_code\": \"ABCD12345678\", ///补差对应的商家券Code\n  \"transaction_id\": \"4200000913202101152566792388\",///补差对应的微信支付单号\n  \"payer_merchant\": \"1900000001\",///补差扣款商户号\n  \"payee_merchant\": \"1900000002\",///补差入账商户号\n  \"amount\": 100,///补差付款金额，单位为分\n  \"description\": \"20210115DESCRIPTION\",///补差付款描述\t\n  \"status\": \"SUCCESS\", ///补差付款单据状态，枚举值ACCEPTED：受理成功 SUCCESS：补差补款成功 FAIL：补差付款失败 RETURNING：补差回退中 PARTIAL_RETURN：补差部分回退 FULL_RETURN：补差全额回退\n  \"success_time\": \"2021-01-20T10:29:35.120+08:00\",///仅在补差付款成功时，返回完成时间。遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"out_subsidy_no\": \"subsidy-abcd-12345678\",///商户发起补差请求生成的单号\n  \"create_time\": \"2021-01-20T10:29:35.120+08:00\" ///补差付款单据创建时间。遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "委托营销",
+					"item": [
+						{
+							"name": "建立合作关系",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Idempotency-Key",
+										"value": "12345",
+										"description": "业务请求幂等值，商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_5_1.shtml\n   接口说明：该接口主要为商户提供营销资源的授权能力，可授权给其他商户或小程序，方便商户间的互利合作。\n   注意：业务请求幂等值通过 HTTP头部 Idempotency-Key：传递。\n业务请求幂等值，商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号\n */\n{\n  \"authorized_data\" : {\n    \"business_type\" : \"FAVOR_STOCK\", ///授权业务类别，枚举值： FAVOR_STOCK：代金券批次（暂不支持合作方为商户的场景） BUSIFAVOR_STOCK：商家券批次\n    \"stock_id\" : \"2433405\" ///授权代金券或商家券批次ID，授权业务类别为商家券批次或代金券批次时，此参数必填。\n  },\n  \"partner\" : {\n    \"appid\" : \"wx4e1916a585d1f4e9\", ///合作方APPID，合作方类别为APPID时必填。\n    \"type\" : \"APPID\" ///合作方类别，枚举值：APPID：合作方为APPID ，MERCHANT：合作方为商户\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/partnerships/build",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"partnerships",
+										"build"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Idempotency-Key",
+												"value": "12345",
+												"description": "业务请求幂等值，商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_5_1.shtml\n   接口说明：该接口主要为商户提供营销资源的授权能力，可授权给其他商户或小程序，方便商户间的互利合作。\n   注意：业务请求幂等值通过 HTTP头部 Idempotency-Key：传递。\n业务请求幂等值，商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号\n */\n{\n  \"authorized_data\" : {\n    \"business_type\" : \"FAVOR_STOCK\", ///授权业务类别，枚举值： FAVOR_STOCK：代金券批次（暂不支持合作方为商户的场景） BUSIFAVOR_STOCK：商家券批次\n    \"stock_id\" : \"2433405\" ///授权代金券或商家券批次ID，授权业务类别为商家券批次或代金券批次时，此参数必填。\n  },\n  \"partner\" : {\n    \"appid\" : \"wx4e1916a585d1f4e9\", ///合作方APPID，合作方类别为APPID时必填。\n    \"type\" : \"APPID\" ///合作方类别，枚举值：APPID：合作方为APPID ，MERCHANT：合作方为商户\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/partnerships/build",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"partnerships",
+												"build"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\t\n \"authorized_data\" : {\n      \"business_type\" : \"FAVOR_STOCK\", ///授权业务类别，枚举值：FAVOR_STOCK：代金券批次，BUSIFAVOR_STOCK：商家券批次\n      \"scenarios\":[\"\"], ///授权场景（该字段暂未开放）\n      \"stock_id\" : \"2433405\" ///授权代金券或商家券批次ID\n    },\n   \"update_time\" : \"2015-05-20T13:29:35.120+08:00\", ///更新时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n   \"partner\" : {\n        \"appid\" : \"wx4e1916a585d1f4e9\", ///合作方的APPID\n        \"type\" : \"APPID\" ///合作方类别，枚举值：APPID：合作方为APPID ,MERCHANT：合作方为商户\n    },\n   \"create_time\" : \"2015-05-20T13:29:35.120+08:00\", ///创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n   \"build_time\" : \"2015-05-20T13:29:35.120+08:00\", ///建立合作关系时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n   \"state\" : \"ESTABLISHED\" ///合作状态，枚举值：ESTABLISHED：已建立 ，TERMINATED：已终止\n}"
+								}
+							]
+						},
+						{
+							"name": "查询合作关系列表",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/partnerships?authorized_data=%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d&partner=%7b%22type%22%3a%22APPID%22%7d&offset=0&limit=5",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"partnerships"
+									],
+									"query": [
+										{
+											"key": "authorized_data",
+											"value": "%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d",
+											"description": "被授权的数据。"
+										},
+										{
+											"key": "partner",
+											"value": "%7b%22type%22%3a%22APPID%22%7d",
+											"description": "合作方相关的信息，商户自定义字段。"
+										},
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "分页页码，页码从0开始。"
+										},
+										{
+											"key": "limit",
+											"value": "5",
+											"description": "分页大小，最大50。 不传默认为20。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/marketing/partnerships?authorized_data=%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d&partner=%7b%22type%22%3a%22APPID%22%7d&offset=0&limit=5",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"partnerships"
+											],
+											"query": [
+												{
+													"key": "authorized_data",
+													"value": "%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d"
+												},
+												{
+													"key": "partner",
+													"value": "%7b%22type%22%3a%22APPID%22%7d"
+												},
+												{
+													"key": "offset",
+													"value": "0"
+												},
+												{
+													"key": "limit",
+													"value": "5"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/// 字段参数说明看文档说明 https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_5_3.shtml\n{\t\n \"data\":[{\n       \"authorized_data\":{\n          \"business_type\":\"FAVOR_STOCK\",\n          \"stock_id\":\"2433405\"\n\t\t},\n\t   \"partner\":{\n\t\t   \"appid\":\"wx4e1916a585d1f4e9\",\n\t\t   \"type\":\"APPID\"\n\t\t },\n       \"update_time\":\"2015-05-20T13:29:35.120+08:00\",\n       \"create_time\":\"2015-05-20T13:29:35.120+08:00\",\n       \"build_time\":\"2015-05-20T13:29:35.120+08:00\",\n       \"terminate_time\":\"2015-05-20T13:29:35.120+08:00\"\n    },\n\t{\n       \"authorized_data\":{\n          \"business_type\":\"FAVOR_STOCK\",\n          \"stock_id\":\"2433405\"\n\t\t},\n\t   \"partner\":{\n\t\t   \"appid\":\"wx4e1916a585d1f4e9\",\n\t\t   \"type\":\"APPID\"\n\t\t },\n       \"update_time\":\"2015-05-20T13:29:35.120+08:00\",\n       \"create_time\":\"2015-05-20T13:29:35.120+08:00\",\n       \"build_time\":\"2015-05-20T13:29:35.120+08:00\",\n       \"terminate_time\":\"2015-05-20T13:29:35.120+08:00\"\n    }\n  ],\n   \"offset\":0,\n   \"total_count\":2,\n   \"limit\":5\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "支付有礼",
+					"item": [
+						{
+							"name": "创建全场满额送活动",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"activity_base_info\": {\n    \"activity_name\": \"良品铺子回馈活动\",\n    \"activity_second_title\": \"海飞丝的券\",\n    \"merchant_logo_url\": \"https://tool.oschina.net/regex.jpg\",\n    \"background_color\": \"COLOR010\",\n    \"begin_time\": \"2015-05-20T13:29:35+08:00\",\n    \"end_time\": \"2015-05-20T13:29:35+08:00\",\n    \"available_periods\": {\n      \"available_time\": [\n        {\n          \"begin_time\": \"2015-05-20T00:00:00+08:00\",\n          \"end_time\": \"2015-05-20T23:59:59+08:00\"\n        }\n      ],\n      \"available_day_time\": [\n        {\n          \"begin_day_time\": \"110000\",\n          \"end_day_time\": \"135959\"\n        }\n      ]\n    },\n    \"out_request_no\": \"100002322019090134234sfdf\",\n    \"delivery_purpose\": \"OFF_LINE_PAY\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"award_send_rule\": {\n    \"transaction_amount_minimum\": 100,\n    \"send_content\": \"SINGLE_COUPON\",\n    \"award_type\": \"BUSIFAVOR\",\n    \"award_list\": [\n      {\n        \"stock_id\": \"98065001\",\n        \"original_image_url\": \"https://tool.oschina.net/regex.jpg\",\n        \"thumbnail_url\": \"https://tool.oschina.net/regex.jpg\"\n      }\n    ],\n    \"merchant_option\": \"MANUAL_INPUT_MERCHANT\",\n    \"merchant_id_list\": [\n      \"10000022\",\n      \"10000023\"\n    ]\n  },\n  \"advanced_setting\": {\n    \"delivery_user_category\": \"DELIVERY_MEMBER_PERSON\",\n    \"merchant_member_appid\": \"34567890\",\n    \"goods_tags\": [\n      \"xxx\",\n      \"yyy\"\n    ]\n  }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/unique-threshold-activity",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"unique-threshold-activity"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "查询活动详情接口",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities",
+										"10028001"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "查询活动发券商户号",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001/merchants?offset=1&limit=20",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities",
+										"10028001",
+										"merchants"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "查询活动指定商品列表",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001/goods?offset=1&limit=20",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities",
+										"10028001",
+										"goods"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "终止活动",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001/terminate",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities",
+										"10028001",
+										"terminate"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "新增活动发券商户号",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ],\n  \"add_request_no\" : \"100002322019090134234sfdf\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/add",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities",
+										"{activity_id}",
+										"merchants",
+										"add"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "获取支付有礼活动列表",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities?offset=0&limit=10&activity_status=ONGOING_ACT_STATUS",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "0"
+										},
+										{
+											"key": "limit",
+											"value": "10"
+										},
+										{
+											"key": "activity_status",
+											"value": "ONGOING_ACT_STATUS"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "删除活动发券商户号",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ],\n  \"delete_request_no\" : \"100002322019090134234sfdf\"\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/delete",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"marketing",
+										"paygiftactivity",
+										"activities",
+										"{activity_id}",
+										"merchants",
+										"delete"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "资金应用",
+			"item": [
+				{
+					"name": "商家转账到零钱",
+					"item": [
+						{
+							"name": "发起商家转账",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter4_3_1.shtml\n   接口说明：商户可以通过该接口同时向多个用户微信零钱进行转账操作。\n   注意：使用postman调用该接口时，需要在商户后台配置自己本机的出口IP地址，如果宽带无公网IP，配置是无效的，无法调用 */\n{\n  \"appid\": \"{{appid}}\",///商户号所绑定的APPID，可以为服务号或小程序APPID\n  \"out_batch_no\": \"pay2022022222220222\", ///商户系统内部的商家批次单号，要求此参数只能由数字、大小写字母组成，在商户系统内部唯一\n  \"batch_name\": \"2022年2月深圳分部报销单\",///该笔转账单的名称\n  \"batch_remark\": \"2022年2月深圳分部报销单\",///批次转账说明，UTF8编码，最多允许32个字符\n  \"total_amount\": 200000,///转账金额单位为“分”。转账总金额必须与批次内所有明细转账金额之和保持一致，否则无法发起转账操作\n  \"total_num\": 1, ///一个转账批次单最多发起三千笔转账。转账总笔数必须与批次内所有明细之和保持一致，否则无法发起转账操作\n  \"transfer_detail_list\": [\n    {\n      \"out_detail_no\": \"MX2022022200001\",///商户系统内部区分转账批次单下不同转账明细单的唯一标识，要求此参数只能由数字、大小写字母组成，此单号商户号下唯一，不可重复\n      \"transfer_amount\": 200000,///针对单一用户的转账金额，单位为“分”，最低为0.3元，后台默认为1元，如果遇到报错，需要手动去商家平台进行额度设置\n      \"transfer_remark\": \"2022年2月报销\",///单条转账备注（微信用户会收到该备注），UTF8编码，最多允许32个字符\n      \"openid\": \"{{\",///openid是微信用户在appid下的唯一用户标识（appid不同，则获取到的openid就不同）\n      \"user_name\": \"757b340b45ebef5467rter35gf464344v3542sdf4t6re4tb4f54ty45t4yyry45\"\n      /* 1、明细转账金额 >= 2,000元，收款用户姓名必填；小于0.3不支持校验\n         2、同一批次转账明细中，收款用户姓名字段需全部填写、或全部不填写；\n         3、 若传入收款用户姓名，微信支付会校验用户openID与姓名是否一致，并提供电子回单；\n         4、收款方姓名。采用标准RSA算法，公钥由微信侧提供\n         5、该字段需进行加密处理，加密方法详见敏感信息加密说明。(提醒：必须在HTTP头中上送Wechatpay-Serial)\n         6、商户需确保收集用户的姓名信息，以及向微信支付传输用户姓名和账号标识信息做一致性校验已合法征得用户授权 */\n    }\n  ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/batches",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"batches"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter4_3_1.shtml\n   接口说明：商户可以通过该接口同时向多个用户微信零钱进行转账操作。\n   注意：使用postman调用该接口时，需要在商户后台配置自己本机的出口IP地址，如果宽带无公网IP，配置是无效的，无法调用 */\n{\n  \"appid\": \"{{appid}}\",///商户号所绑定的APPID，可以为服务号或小程序APPID\n  \"out_batch_no\": \"pay2022022222220222\", ///商户系统内部的商家批次单号，要求此参数只能由数字、大小写字母组成，在商户系统内部唯一\n  \"batch_name\": \"2022年2月深圳分部报销单\",///该笔转账单的名称\n  \"batch_remark\": \"2022年2月深圳分部报销单\",///批次转账说明，UTF8编码，最多允许32个字符\n  \"total_amount\": 200000,///转账金额单位为“分”。转账总金额必须与批次内所有明细转账金额之和保持一致，否则无法发起转账操作\n  \"total_num\": 1, ///一个转账批次单最多发起三千笔转账。转账总笔数必须与批次内所有明细之和保持一致，否则无法发起转账操作\n  \"transfer_detail_list\": [\n    {\n      \"out_detail_no\": \"MX2022022200001\",///商户系统内部区分转账批次单下不同转账明细单的唯一标识，要求此参数只能由数字、大小写字母组成，此单号商户号下唯一，不可重复\n      \"transfer_amount\": 200000,///针对单一用户的转账金额，单位为“分”，最低为0.3元，后台默认为1元，如果遇到报错，需要手动去商家平台进行额度设置\n      \"transfer_remark\": \"2022年2月报销\",///单条转账备注（微信用户会收到该备注），UTF8编码，最多允许32个字符\n      \"openid\": \"{{\",///openid是微信用户在appid下的唯一用户标识（appid不同，则获取到的openid就不同）\n      \"user_name\": \"757b340b45ebef5467rter35gf464344v3542sdf4t6re4tb4f54ty45t4yyry45\"\n      /* 1、明细转账金额 >= 2,000元，收款用户姓名必填；小于0.3不支持校验\n         2、同一批次转账明细中，收款用户姓名字段需全部填写、或全部不填写；\n         3、 若传入收款用户姓名，微信支付会校验用户openID与姓名是否一致，并提供电子回单；\n         4、收款方姓名。采用标准RSA算法，公钥由微信侧提供\n         5、该字段需进行加密处理，加密方法详见敏感信息加密说明。(提醒：必须在HTTP头中上送Wechatpay-Serial)\n         6、商户需确保收集用户的姓名信息，以及向微信支付传输用户姓名和账号标识信息做一致性校验已合法征得用户授权 */\n    }\n  ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/batches",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"batches"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"out_batch_no\": \"pay2022022222220222\", ///商户系统内部的商家批次单号,请求什么返回什么\n  \"batch_id\": \"1030000071100999991182020050700019480001\",///微信批次单号，微信商家转账系统返回的唯一标识，与out_batch_no相对应\n  \"create_time\": \"2022-02-22T22:22:22.120+08:00\"///批次受理成功时返回，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE \n  /* 注意：受理成功不代表转账成功，这里需要要查单来确认转账结果，如果遇到转账失败，无论什么错误都不建议原单重试，确认未出资情况下，根据错误情况确定是否要换单重发 */\n}"
+								}
+							]
+						},
+						{
+							"name": "微信批次单号查询批次单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"batches",
+										"batch-id",
+										"{{此处替换为要查询的微信批次单号}}"
+									],
+									"query": [
+										{
+											"key": "need_query_detail",
+											"value": "true",
+											"description": "当转账批次单状态为“FINISHED”（已完成）时，才会返回满足条件的转账明细单，商户可以自行选择是否查询转账明细单，\n枚举值：\ntrue：是；\nfalse：否，默认否。"
+										},
+										{
+											"key": "detail_status",
+											"value": "ALL",
+											"description": "查询指定状态的转账明细单，当need_query_detail为true时，该字段必填\nALL:全部。需要同时查询转账成功和转账失败的明细单\nSUCCESS:转账成功。只查询转账成功的明细单\nFAIL:转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单）"
+										},
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "该次请求资源的起始位置，从0开始，默认值为0"
+										},
+										{
+											"key": "limit",
+											"value": "20",
+											"description": "该次请求可返回的最大明细条数，最小20条，最大100条，不传则默认20条。不足20条按实际条数返回"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"batches",
+												"batch-id",
+												"{{此处替换为要查询的微信批次单号}}"
+											],
+											"query": [
+												{
+													"key": "need_query_detail",
+													"value": "true",
+													"description": "当转账批次单状态为“FINISHED”（已完成）时，才会返回满足条件的转账明细单，商户可以自行选择是否查询转账明细单，\n枚举值：\ntrue：是；\nfalse：否，默认否。"
+												},
+												{
+													"key": "detail_status",
+													"value": "ALL",
+													"description": "查询指定状态的转账明细单，当need_query_detail为true时，该字段必填\nALL:全部。需要同时查询转账成功和转账失败的明细单\nSUCCESS:转账成功。只查询转账成功的明细单\nFAIL:转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单）"
+												},
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "该次请求资源的起始位置，从0开始，默认值为0"
+												},
+												{
+													"key": "limit",
+													"value": "20",
+													"description": "该次请求可返回的最大明细条数，最小20条，最大100条，不传则默认20条。不足20条按实际条数返回"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"transfer_batch\": {\n    \"mchid\": \"1900001109\", ///发起转账的商户号\n    \"out_batch_no\": \"pay2022022222220222\", ///商户系统内部的商家批次单号\n    \"batch_id\": \"1030000071100999991182020050700019480001\",///微信批次单号，微信商家转账系统返回的唯一标识，与out_batch_no参数一一对应\n    \"appid\": \"wxf636efh567hg4356\",///商户号所绑定的APPID，可以为服务号或小程序APPID\n    \"batch_status\": \"ACCEPTED\", ///批次状态 枚举值：WAIT_PAY：待付款，商户员工确认付款阶段 ACCEPTED:已受理。批次已受理成功，若发起批量转账的30分钟后，转账批次单仍处于该状态，可能原因是商户账户余额不足等。商户可查询账户资金流水，若该笔转账批次单的扣款已经发生，则表示批次已经进入转账中，请再次查单确认 PROCESSING:转账中。已开始处理批次内的转账明细单 FINISHED：已完成。批次内的所有转账明细单都已处理完成 CLOSED：已关闭。可查询具体的批次关闭原因确认\n    \"batch_type\": \"API\",///批次类型，就是通过什么方式发起的转账，枚举值：API：API方式发起 WEB：页面方式发起（指的是商户后台发放）\n    \"batch_name\": \"2022年2月深圳分部报销单\", ///该笔转账单的名称\n    \"batch_remark\": \"2022年2月深圳分部报销单\",///该笔批次转账的说明\n    \"close_reason\": \"OVERDUE_CLOSE\",///批次关闭原因 如果批次单状态为“CLOSED”（已关闭），则有关闭原因 MERCHANT_REVOCATION：商户主动撤销 OVERDUE_CLOSE：系统超时关闭\n    \"total_amount\": 200000,///该笔转账批次转账总金额，单位为“分”\n    \"total_num\": 200,///转账总笔数\n    \"create_time\": \"2022-02-22T22:22:22.120+08:00\", ///批次创建时间\t批次受理成功时返回，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n    \"update_time\": \"2022-02-22T22:22:25.120+08:00\",///批次更新时间\t批次最近一次状态变更的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n    \"success_amount\": 3900000, ///转账成功的金额，单位为分。当批次状态为“PROCESSING”（转账中）时，转账成功金额随时可能变化\n    \"success_num\": 199, ///转账成功的笔数。当批次状态为“PROCESSING”（转账中）时，转账成功笔数随时可能变化\n    \"fail_amount\": 100000, ///转账失败的金额，单位为分\n    \"fail_num\": 1 ///转账失败的笔数\n  },\n  \"transfer_detail_list\": [\n    {\n      \"detail_id\": \"1040000071100999991182020050700019500100\", ///微信支付系统内部区分转账批次单下不同转账明细单的唯一标识\n      \"out_detail_no\": \"MX2022022200001\",///商户系统内部区分转账批次单下不同转账明细单的唯一标识，要求此参数只能由数字、大小写字母组成，此单号商户号下唯一，与detail_id一一对应\n      \"detail_status\": \"SUCCESS\" /*明细单状态：枚举值：\n            PROCESSING：转账中。正在处理中，转账结果尚未明确\n            SUCCESS：转账成功\n            FAIL：转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单） */\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "微信明细单号查询明细单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}/details/detail-id/{{此处要替换为要查询的微信明细单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"batches",
+										"batch-id",
+										"{{此处替换为要查询的微信批次单号}}",
+										"details",
+										"detail-id",
+										"{{此处要替换为要查询的微信明细单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}/details/detail-id/{{此处要替换为要查询的微信明细单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"batches",
+												"batch-id",
+												"{{此处替换为要查询的微信批次单号}}",
+												"details",
+												"detail-id",
+												"{{此处要替换为要查询的微信明细单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"mchid\": \"1900001109\",///发起转账的商户号\n  \"out_batch_no\": \"pay2022022222220222\",///商户系统内部的商家批次单号\n  \"batch_id\": \"1030000071100999991182020050700019480001\",///微信批次单号，微信商家转账系统返回的唯一标识，与out_batch_no参数一一对应\n  \"appid\": \"wxf636efh567hg4356\",///商户号所绑定的APPID，可以为服务号或小程序APPID\n  \"out_detail_no\": \"MX2022022200001\",///商户系统内部区分转账批次单下不同转账明细单的唯一标识，此参数只由数字、大小写字母组成，此单号商户号下唯一，与detail_id一一对应\n  \"detail_id\": \"1040000071100999991182020050700019500100\",//////微信支付系统内部区分转账批次单下不同转账明细单的唯一标识\n  \"detail_status\": \"SUCCESS\",///明细单状态：枚举值：PROCESSING：转账中。正在处理中，转账结果尚未明确 SUCCESS：转账成功 FAIL：转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单）\n  \"transfer_amount\": 200000, ///转账金额,单位为\"分\"\n  \"transfer_remark\": \"2022年2月报销\",///单条转账备注（微信用户会收到该备注），UTF8编码，最多32个字符\n  \"fail_reason\": \"ACCOUNT_FROZEN\", /* 如果转账失败则有失败原因\n         ACCOUNT_FROZEN：账户冻结 REAL_NAME_CHECK_FAIL：用户未实名 NAME_NOT_CORRECT：用户姓名校验失败 OPENID_INVALID：Openid校验失败\n        TRANSFER_QUOTA_EXCEED：超过用户单笔收款额度 DAY_RECEIVED_QUOTA_EXCEED：超过用户单日收款额度 MONTH_RECEIVED_QUOTA_EXCEED：超过用户单月收款额度\n        DAY_RECEIVED_COUNT_EXCEED：超过用户单日收款次数 PRODUCT_AUTH_CHECK_FAIL：产品权限校验失败 OVERDUE_CLOSE：转账关闭 ID_CARD_NOT_CORRECT：用户身份证校验失败\n        ACCOUNT_NOT_EXIST：用户账户不存在 TRANSFER_RISK：转账存在风险 REALNAME_ACCOUNT_RECEIVED_QUOTA_EXCEED：用户账户收款受限，请引导用户在微信支付查看详情\n        RECEIVE_ACCOUNT_NOT_PERMMIT：未配置该用户为转账收款人 PAYER_ACCOUNT_ABNORMAL：商户账户付款受限，可前往商户平台-违约记录获取解除功能限制指引\n        PAYEE_ACCOUNT_ABNORMAL：用户账户收款异常，请引导用户完善其在微信支付的身份信息以继续收款 TRANSFER_REMARK_SET_FAIL：转账备注设置失败，请调整对应文案后重新再试 */\n  \"openid\": \"o-MYE42l80oelYMDE34nYD456Xoy\",///收款用户标识，openid是该微信用户在该appid下的唯一用户标识（appid不同，则获取到的openid就不同）\n  \"user_name\": \"757b340b45ebef5467rter35gf464344v3542sdf4t6re4tb4f54ty45t4yyry45\", ///收款用户真实姓名1、商户转账时传入了收款用户姓名、查询时会返回收款用户姓名； 2、收款方姓名采用标准RSA算法，公钥由微信侧提供\n  \"initiate_time\": \"2015-05-20T13:29:35.120+08:00\", ///转账发起的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n  \"update_time\": \"2015-05-20T13:29:35.120+08:00\" ///明细最后一次状态变更的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "商家批次单号查询批次单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"batches",
+										"out-batch-no",
+										"{{此处替换为要查询的微信批次单号}}"
+									],
+									"query": [
+										{
+											"key": "need_query_detail",
+											"value": "true",
+											"description": "当转账批次单状态为“FINISHED”（已完成）时，才会返回满足条件的转账明细单，商户可以自行选择是否查询转账明细单，\n枚举值：\ntrue：是；\nfalse：否，默认否。"
+										},
+										{
+											"key": "detail_status",
+											"value": "ALL",
+											"description": "查询指定状态的转账明细单，当need_query_detail为true时，该字段必填\nALL:全部。需要同时查询转账成功和转账失败的明细单\nSUCCESS:转账成功。只查询转账成功的明细单\nFAIL:转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单）"
+										},
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "该次请求资源的起始位置，从0开始，默认值为0"
+										},
+										{
+											"key": "limit",
+											"value": "20",
+											"description": "该次请求可返回的最大明细条数，最小20条，最大100条，不传则默认20条。不足20条按实际条数返回"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"batches",
+												"out-batch-no",
+												"{{此处替换为要查询的微信批次单号}}"
+											],
+											"query": [
+												{
+													"key": "need_query_detail",
+													"value": "true",
+													"description": "当转账批次单状态为“FINISHED”（已完成）时，才会返回满足条件的转账明细单，商户可以自行选择是否查询转账明细单，\n枚举值：\ntrue：是；\nfalse：否，默认否。"
+												},
+												{
+													"key": "detail_status",
+													"value": "ALL",
+													"description": "查询指定状态的转账明细单，当need_query_detail为true时，该字段必填\nALL:全部。需要同时查询转账成功和转账失败的明细单\nSUCCESS:转账成功。只查询转账成功的明细单\nFAIL:转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单）"
+												},
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "该次请求资源的起始位置，从0开始，默认值为0"
+												},
+												{
+													"key": "limit",
+													"value": "20",
+													"description": "该次请求可返回的最大明细条数，最小20条，最大100条，不传则默认20条。不足20条按实际条数返回"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"transfer_batch\": {\n    \"mchid\": \"1900001109\", ///发起转账的商户号\n    \"out_batch_no\": \"pay2022022222220222\", ///商户系统内部的商家批次单号\n    \"batch_id\": \"1030000071100999991182020050700019480001\",///微信批次单号，微信商家转账系统返回的唯一标识，与out_batch_no参数一一对应\n    \"appid\": \"wxf636efh567hg4356\",///商户号所绑定的APPID，可以为服务号或小程序APPID\n    \"batch_status\": \"ACCEPTED\", ///批次状态 枚举值：WAIT_PAY：待付款，商户员工确认付款阶段 ACCEPTED:已受理。批次已受理成功，若发起批量转账的30分钟后，转账批次单仍处于该状态，可能原因是商户账户余额不足等。商户可查询账户资金流水，若该笔转账批次单的扣款已经发生，则表示批次已经进入转账中，请再次查单确认 PROCESSING:转账中。已开始处理批次内的转账明细单 FINISHED：已完成。批次内的所有转账明细单都已处理完成 CLOSED：已关闭。可查询具体的批次关闭原因确认\n    \"batch_type\": \"API\",///批次类型，就是通过什么方式发起的转账，枚举值：API：API方式发起 WEB：页面方式发起（指的是商户后台发放）\n    \"batch_name\": \"2022年2月深圳分部报销单\", ///该笔转账单的名称\n    \"batch_remark\": \"2022年2月深圳分部报销单\",///该笔批次转账的说明\n    \"close_reason\": \"OVERDUE_CLOSE\",///批次关闭原因 如果批次单状态为“CLOSED”（已关闭），则有关闭原因 MERCHANT_REVOCATION：商户主动撤销 OVERDUE_CLOSE：系统超时关闭\n    \"total_amount\": 200000,///该笔转账批次转账总金额，单位为“分”\n    \"total_num\": 200,///转账总笔数\n    \"create_time\": \"2022-02-22T22:22:22.120+08:00\", ///批次创建时间\t批次受理成功时返回，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n    \"update_time\": \"2022-02-22T22:22:25.120+08:00\",///批次更新时间\t批次最近一次状态变更的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n    \"success_amount\": 3900000, ///转账成功的金额，单位为分。当批次状态为“PROCESSING”（转账中）时，转账成功金额随时可能变化\n    \"success_num\": 199, ///转账成功的笔数。当批次状态为“PROCESSING”（转账中）时，转账成功笔数随时可能变化\n    \"fail_amount\": 100000, ///转账失败的金额，单位为分\n    \"fail_num\": 1 ///转账失败的笔数\n  },\n  \"transfer_detail_list\": [\n    {\n      \"detail_id\": \"1040000071100999991182020050700019500100\", ///微信支付系统内部区分转账批次单下不同转账明细单的唯一标识\n      \"out_detail_no\": \"MX2022022200001\",///商户系统内部区分转账批次单下不同转账明细单的唯一标识，要求此参数只能由数字、大小写字母组成，此单号商户号下唯一，与detail_id一一对应\n      \"detail_status\": \"SUCCESS\" /*明细单状态：枚举值：\n            PROCESSING：转账中。正在处理中，转账结果尚未明确\n            SUCCESS：转账成功\n            FAIL：转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单） */\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "商家明细单号查询明细单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的商家批次单号}}/details/out-detail-no/{{此处要替换为要查询的商家明细单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"batches",
+										"out-batch-no",
+										"{{此处替换为要查询的商家批次单号}}",
+										"details",
+										"out-detail-no",
+										"{{此处要替换为要查询的商家明细单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的商家批次单号}}/details/out-detail-no/{{此处要替换为要查询的商家明细单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"batches",
+												"out-batch-no",
+												"{{此处替换为要查询的商家批次单号}}",
+												"details",
+												"out-detail-no",
+												"{{此处要替换为要查询的商家明细单号}}"
+											]
+										}
+									},
+									"status": "200_OK",
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"mchid\": \"1900001109\",///发起转账的商户号\n  \"out_batch_no\": \"pay2022022222220222\",///商户系统内部的商家批次单号\n  \"batch_id\": \"1030000071100999991182020050700019480001\",///微信批次单号，微信商家转账系统返回的唯一标识，与out_batch_no参数一一对应\n  \"appid\": \"wxf636efh567hg4356\",///商户号所绑定的APPID，可以为服务号或小程序APPID\n  \"out_detail_no\": \"MX2022022200001\",///商户系统内部区分转账批次单下不同转账明细单的唯一标识，此参数只由数字、大小写字母组成，此单号商户号下唯一，与detail_id一一对应\n  \"detail_id\": \"1040000071100999991182020050700019500100\",//////微信支付系统内部区分转账批次单下不同转账明细单的唯一标识\n  \"detail_status\": \"SUCCESS\",///明细单状态：枚举值：PROCESSING：转账中。正在处理中，转账结果尚未明确 SUCCESS：转账成功 FAIL：转账失败。需要通过查询明细单接口确认明细失败原因后，再决定是否重新发起对该笔明细单的转账（并非整个转账批次单）\n  \"transfer_amount\": 200000, ///转账金额,单位为\"分\"\n  \"transfer_remark\": \"2022年2月报销\",///单条转账备注（微信用户会收到该备注），UTF8编码，最多32个字符\n  \"fail_reason\": \"ACCOUNT_FROZEN\", /* 如果转账失败则有失败原因\n         ACCOUNT_FROZEN：账户冻结 REAL_NAME_CHECK_FAIL：用户未实名 NAME_NOT_CORRECT：用户姓名校验失败 OPENID_INVALID：Openid校验失败\n        TRANSFER_QUOTA_EXCEED：超过用户单笔收款额度 DAY_RECEIVED_QUOTA_EXCEED：超过用户单日收款额度 MONTH_RECEIVED_QUOTA_EXCEED：超过用户单月收款额度\n        DAY_RECEIVED_COUNT_EXCEED：超过用户单日收款次数 PRODUCT_AUTH_CHECK_FAIL：产品权限校验失败 OVERDUE_CLOSE：转账关闭 ID_CARD_NOT_CORRECT：用户身份证校验失败\n        ACCOUNT_NOT_EXIST：用户账户不存在 TRANSFER_RISK：转账存在风险 REALNAME_ACCOUNT_RECEIVED_QUOTA_EXCEED：用户账户收款受限，请引导用户在微信支付查看详情\n        RECEIVE_ACCOUNT_NOT_PERMMIT：未配置该用户为转账收款人 PAYER_ACCOUNT_ABNORMAL：商户账户付款受限，可前往商户平台-违约记录获取解除功能限制指引\n        PAYEE_ACCOUNT_ABNORMAL：用户账户收款异常，请引导用户完善其在微信支付的身份信息以继续收款 TRANSFER_REMARK_SET_FAIL：转账备注设置失败，请调整对应文案后重新再试 */\n  \"openid\": \"o-MYE42l80oelYMDE34nYD456Xoy\",///收款用户标识，openid是该微信用户在该appid下的唯一用户标识（appid不同，则获取到的openid就不同）\n  \"user_name\": \"757b340b45ebef5467rter35gf464344v3542sdf4t6re4tb4f54ty45t4yyry45\", ///收款用户真实姓名1、商户转账时传入了收款用户姓名、查询时会返回收款用户姓名； 2、收款方姓名采用标准RSA算法，公钥由微信侧提供\n  \"initiate_time\": \"2015-05-20T13:29:35.120+08:00\", ///转账发起的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n  \"update_time\": \"2015-05-20T13:29:35.120+08:00\" ///明细最后一次状态变更的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "转账电子回单申请受理",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter4_3_7.shtml\n   接口说明：转账电子回单申请受理接口，商户通过该接口可以申请受理电子回单服务。\n   注意：\n1、发起转账时传入了收款用户姓名，支持申请电子回单；\n2、支持受理最近30天内的转账明批次单；\n3、仅支持已完成状态且至少一笔成功记录的批次获取电子回单(不满足条件返回：400 INVALID_REQUEST)； */\n{\n  \"out_batch_no\": \"pay2022022222220222\" ///商户系统内部的发起转账的商家批次单号，要求此参数只能由数字、大小写字母组成，在商户系统内部唯一\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/bill-receipt",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"bill-receipt"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter4_3_7.shtml\n   接口说明：转账电子回单申请受理接口，商户通过该接口可以申请受理电子回单服务。\n   注意：\n1、发起转账时传入了收款用户姓名，支持申请电子回单；\n2、支持受理最近30天内的转账明批次单；\n3、仅支持已完成状态且至少一笔成功记录的批次获取电子回单(不满足条件返回：400 INVALID_REQUEST)； */\n{\n  \"out_batch_no\": \"pay2022022222220222\" ///商户系统内部的发起转账的商家批次单号，要求此参数只能由数字、大小写字母组成，在商户系统内部唯一\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/bill-receipt",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"bill-receipt"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"out_batch_no\": \"pay2022022222220222\", ///申请电子回单的商家批次单号\n  \"signature_no\": \"1050000010509999485212020110200058820001\",///电子回单申请单号，申请单据的唯一标识\n  \"signature_status\": \"ACCEPTED\", ///电子回单状态 枚举值：ACCEPTED:已受理，电子签章已受理成功 FINISHED:已完成。电子签章已处理完成\n  \"hash_type\": \"SHA256\", ///电子回单文件的hash方法，回单状态为：FINISHED时返回。\n  \"hash_value\": \"DE731F35146A0BEFADE5DB9D1E468D96C01CA8898119C674FEE9F11F4DBE5529\", ///电子回单文件的hash值，用于下载之后验证文件的完整、正确性，回单状态为：FINISHED时返回。\n  \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=xxx\", ///电子回单文件的下载地址，回单状态为：FINISHED时返回。URL有效时长为10分钟，10分钟后需要重新去获取下载地址（但不需要走受理）\n  \"create_time\": \"2022-02-22T22:22:22.120+08:00\", ///电子签章单创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n  \"update_time\": \"2022-02-22T22:22:22.120+08:00\" ///电子签章单最近一次状态变更的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "查询转账电子回单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer/bill-receipt/{{此处替换为要查询的商家批次单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer",
+										"bill-receipt",
+										"{{此处替换为要查询的商家批次单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer/bill-receipt/{out_batch_no}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer",
+												"bill-receipt",
+												"{out_batch_no}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"out_batch_no\": \"pay2022022222220222\", ///申请电子回单的商家批次单号\n  \"signature_no\": \"1050000010509999485212020110200058820001\",///电子回单申请单号，申请单据的唯一标识\n  \"signature_status\": \"ACCEPTED\", ///电子回单状态 枚举值：ACCEPTED:已受理，电子签章已受理成功 FINISHED:已完成。电子签章已处理完成\n  \"hash_type\": \"SHA256\", ///电子回单文件的hash方法，回单状态为：FINISHED时返回。\n  \"hash_value\": \"DE731F35146A0BEFADE5DB9D1E468D96C01CA8898119C674FEE9F11F4DBE5529\", ///电子回单文件的hash值，用于下载之后验证文件的完整、正确性，回单状态为：FINISHED时返回。\n  \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=xxx\", ///电子回单文件的下载地址，回单状态为：FINISHED时返回。URL有效时长为10分钟，10分钟后需要重新去获取下载地址（但不需要走受理）\n  \"create_time\": \"2022-02-22T22:22:22.120+08:00\", ///电子签章单创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n  \"update_time\": \"2022-02-22T22:22:22.120+08:00\" ///电子签章单最近一次状态变更的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss.sss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "转账明细电子回单受理",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter4_3_9.shtml\n   接口说明：受理转账明细电子回单接口，商户通过该接口可以申请受理转账明细单电子回单服务。\n   注意：\n1、发起转账时传入了收款用户姓名，支持申请电子回单；\n2、支持受理最近30天内的转账明批次单；\n3、仅支持已完成状态且至少一笔成功记录的批次获取电子回单(不满足条件返回：400 INVALID_REQUEST)； */\n{\n  \"accept_type\": \"BATCH_TRANSFER\", \n  ///电子回单受理类型：BATCH_TRANSFER：商家转账明细电子回单 TRANSFER_TO_POCKET：企业付款至零钱电子回单 TRANSFER_TO_BANK：企业付款至银行卡电子回单\n  \"out_batch_no\": \"pay2022022222220222\", \n  ///需要电子回单的批量转账明细单所在的转账批次单号，该单号为商户申请转账时生成的商户单号。受理类型为BATCH_TRANSFER时该单号必填，否则该单号留空。\n  \"out_detail_no\": \"MX2022022200001\" \n  ///该单号为商户申请转账时生成的商家转账明细单号。1.受理类型为BATCH_TRANSFER时填写商家批量转账明细单号。 2. 受理类型为TRANSFER_TO_POCKET或TRANSFER_TO_BANK时填写商家转账单号。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer-detail",
+										"electronic-receipts"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter4_3_9.shtml\n   接口说明：受理转账明细电子回单接口，商户通过该接口可以申请受理转账明细单电子回单服务。\n   注意：\n1、发起转账时传入了收款用户姓名，支持申请电子回单；\n2、支持受理最近30天内的转账明批次单；\n3、仅支持已完成状态且至少一笔成功记录的批次获取电子回单(不满足条件返回：400 INVALID_REQUEST)； */\n{\n  \"accept_type\": \"BATCH_TRANSFER\", \n  ///电子回单受理类型：BATCH_TRANSFER：商家转账明细电子回单 TRANSFER_TO_POCKET：企业付款至零钱电子回单 TRANSFER_TO_BANK：企业付款至银行卡电子回单\n  \"out_batch_no\": \"pay2022022222220222\", \n  ///需要电子回单的批量转账明细单所在的转账批次单号，该单号为商户申请转账时生成的商户单号。受理类型为BATCH_TRANSFER时该单号必填，否则该单号留空。\n  \"out_detail_no\": \"MX2022022200001\" \n  ///该单号为商户申请转账时生成的商家转账明细单号。1.受理类型为BATCH_TRANSFER时填写商家批量转账明细单号。 2. 受理类型为TRANSFER_TO_POCKET或TRANSFER_TO_BANK时填写商家转账单号。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer-detail",
+												"electronic-receipts"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"accept_type\": \"BATCH_TRANSFER\", \n  ///电子回单受理类型： BATCH_TRANSFER：批量转账明细电子回单 TRANSFER_TO_POCKET：企业付款至零钱电子回单 TRANSFER_TO_BANK：企业付款至银行卡电子回单\n  \"out_batch_no\": \"pay2022022222220222\",///该单号为商户申请转账时生成的商户单号\n  \"out_detail_no\": \"MX2022022200001\",///该单号为商户申请转账时生成的商家转账明细单号\n  \"signature_no\": \"1050000010509999485212020110200058820001\", ///电子回单受理单号，受理单据的唯一标识\n  \"signature_status\": \"ACCEPTED\",///电子回单状态 枚举值：ACCEPTED:已受理，电子签章已受理成功 FINISHED:已完成。电子签章已处理完成\n  \"hash_type\": \"SHA256\",///电子回单文件的hash方法，回单状态为：FINISHED时返回\n  \"hash_value\": \"DE731F35146A0BEFADE5DB9D1E468D96C01CA8898119C674FEE9F11F4DBE5529\", ///电子回单文件的hash值，用于下载之后验证文件的完整、正确性，回单状态为：FINISHED时返回\n  \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=xxx\" \n  ///电子回单文件的下载地址，回单状态为：FINISHED时返回。URL有效时长为10分钟，10分钟后需要重新去获取下载地址（但不需要走受理）\n}"
+								}
+							]
+						},
+						{
+							"name": "查询转账明细电子回单受理结果",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts?accept_type=BATCH_TRANSFER&out_batch_no=pay2022022222220222&out_detail_no=MX2022022200001",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"transfer-detail",
+										"electronic-receipts"
+									],
+									"query": [
+										{
+											"key": "accept_type",
+											"value": "BATCH_TRANSFER",
+											"description": "电子回单受理类型：BATCH_TRANSFER：批量转账明细电子回单\nTRANSFER_TO_POCKET：企业付款至零钱电子回单\nTRANSFER_TO_BANK：企业付款至银行卡电子回单"
+										},
+										{
+											"key": "out_batch_no",
+											"value": "pay2022022222220222",
+											"description": "需要电子回单的批量转账明细单所在的转账批次单号，该单号为商户申请转账时生成的商户单号。受理类型为BATCH_TRANSFER时该单号必填，否则该单号留空。"
+										},
+										{
+											"key": "out_detail_no",
+											"value": "MX2022022200001",
+											"description": "该单号为商户申请转账时生成的商家转账明细单号。\n1.受理类型为BATCH_TRANSFER时填写商家批量转账明细单号。\n2. 受理类型为TRANSFER_TO_POCKET或TRANSFER_TO_BANK时填写商家转账单号。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts?accept_type=BATCH_TRANSFER&out_batch_no=pay2022022222220222&out_detail_no=MX2022022200001",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"transfer-detail",
+												"electronic-receipts"
+											],
+											"query": [
+												{
+													"key": "accept_type",
+													"value": "BATCH_TRANSFER",
+													"description": "电子回单受理类型：BATCH_TRANSFER：批量转账明细电子回单\nTRANSFER_TO_POCKET：企业付款至零钱电子回单\nTRANSFER_TO_BANK：企业付款至银行卡电子回单"
+												},
+												{
+													"key": "out_batch_no",
+													"value": "pay2022022222220222",
+													"description": "需要电子回单的批量转账明细单所在的转账批次单号，该单号为商户申请转账时生成的商户单号。受理类型为BATCH_TRANSFER时该单号必填，否则该单号留空。"
+												},
+												{
+													"key": "out_detail_no",
+													"value": "MX2022022200001",
+													"description": "该单号为商户申请转账时生成的商家转账明细单号。\n1.受理类型为BATCH_TRANSFER时填写商家批量转账明细单号。\n2. 受理类型为TRANSFER_TO_POCKET或TRANSFER_TO_BANK时填写商家转账单号。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"accept_type\": \"BATCH_TRANSFER\", \n  ///电子回单受理类型： BATCH_TRANSFER：批量转账明细电子回单 TRANSFER_TO_POCKET：企业付款至零钱电子回单 TRANSFER_TO_BANK：企业付款至银行卡电子回单\n  \"out_batch_no\": \"pay2022022222220222\",///该单号为商户申请转账时生成的商户单号\n  \"out_detail_no\": \"MX2022022200001\",///该单号为商户申请转账时生成的商家转账明细单号\n  \"signature_no\": \"1050000010509999485212020110200058820001\", ///电子回单受理单号，受理单据的唯一标识\n  \"signature_status\": \"ACCEPTED\",///电子回单状态 枚举值：ACCEPTED:已受理，电子签章已受理成功 FINISHED:已完成。电子签章已处理完成\n  \"hash_type\": \"SHA256\",///电子回单文件的hash方法，回单状态为：FINISHED时返回\n  \"hash_value\": \"DE731F35146A0BEFADE5DB9D1E468D96C01CA8898119C674FEE9F11F4DBE5529\", ///电子回单文件的hash值，用于下载之后验证文件的完整、正确性，回单状态为：FINISHED时返回\n  \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=xxx\" \n  ///电子回单文件的下载地址，回单状态为：FINISHED时返回。URL有效时长为10分钟，10分钟后需要重新去获取下载地址（但不需要走受理）\n}"
+								}
+							]
+						},
+						{
+							"name": "下载电子回单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+									"protocol": "https",
+									"host": [
+										"api",
+										"mch",
+										"weixin",
+										"qq",
+										"com"
+									],
+									"path": [
+										"v3",
+										"billdownload",
+										"file"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
+											"description": "电子回单文件的下载地址，回单状态为：FINISHED时返回。URL有效时长为10分钟，10分钟后需要重新去获取下载地址（但不需要走受理）"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "分账",
+					"item": [
+						{
+							"name": "请求分账",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"appid\": \"{{appid}}\",///商户号绑定的APPID\n  \"transaction_id\": \"4208450740201411110007820472\",///要分账的微信支付订单号\n  \"out_order_no\": \"P2022111111111100011\",///商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@\n  \"receivers\": [\n    {\n      \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n      \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n      \"amount\": 888,///要分出给接收方的分账金额，单位为“分”，只能为整数，不能超过原订单实际支付金额及最大分账比例金额\n      \"description\": \"分给商户A\"///分账的原因描述，分账账单中需要体现\n    }\n  ],\n  \"unfreeze_unsplit\": true ///1、如果为true，该笔订单剩余未分账的金额会解冻回分账方商户； 2、如果为false，该笔订单剩余未分账的金额不会解冻回分账方商户，可以对该笔订单再次进行分账。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/orders",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"orders"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"appid\": \"{{appid}}\",///商户号绑定的APPID\n  \"transaction_id\": \"4208450740201411110007820472\",///要分账的微信支付订单号\n  \"out_order_no\": \"P2022111111111100011\",///商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@\n  \"receivers\": [\n    {\n      \"type\": \"MERCHANT_ID\",///分账接收方类型，枚举值：1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n      \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n      \"amount\": 888,///要分出给接收方的分账金额，单位为“分”，只能为整数，不能超过原订单实际支付金额及最大分账比例金额\n      \"description\": \"分给商户A\"///分账的原因描述，分账账单中需要体现\n    }\n  ],\n  \"unfreeze_unsplit\": true ///1、如果为true，该笔订单剩余未分账的金额会解冻回分账方商户； 2、如果为false，该笔订单剩余未分账的金额不会解冻回分账方商户，可以对该笔订单再次进行分账。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/orders",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"orders"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"transaction_id\": \"4208450740201411110007820472\",///发起分账的微信支付订单号\n  \"out_order_no\": \"P2022111111111100011\",///商户发起分账请求的系统内部单号\n  \"order_id\": \"3008450740201411110007820472\",///微信分账单号，微信支付系统返回的唯一标识\n  \"state\": \"FINISHED\",///分账单状态（每个接收方的分账结果请查看receivers中的result字段），枚举值： 1、PROCESSING：处理中 2、FINISHED：分账完成\n  \"receivers\": [\n    {\n      \"amount\": 888, ///分账金额，单位为分\n      \"description\": \"分给商户A\",///分账描述，该字段为商户传参\n      \"type\": \"MERCHANT_ID\",//////分账接收方类型，枚举值：1、MERCHANT_ID：商户号 2、PERSONAL_OPENID\n      \"account\": \"1900000109\",//////分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n      \"result\": \"SUCCESS\", ///分账结果，枚举值：1、PENDING：待分账 2、SUCCESS：分账成功 3、CLOSED：已关闭\n      \"fail_reason\": \"ACCOUNT_ABNORMAL\", /* 分账失败原因，当分账结果result为CLOSED（已关闭）时，返回该字段 枚举值：\n        1、ACCOUNT_ABNORMAL：分账接收账户异常   2、NO_RELATION：分账关系已解除  3、RECEIVER_HIGH_RISK：高风险接收方 4、RECEIVER_REAL_NAME_NOT_VERIFIED：接收方未实名\n        5、NO_AUTH：分账权限已解除  6、RECEIVER_RECEIPT_LIMIT：接收方已达收款限额   7、PAYER_ACCOUNT_ABNORMAL：分出方账户异常 */\n      \"detail_id\": \"36011111111111111111111\", ///微信分账明细单号，每笔分账业务执行的明细单号，可与资金账单对账使用\n      \"create_time\": \"2015-05-20T13:29:35+08:00\",///分账创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n      \"finish_time\": \"2015-05-20T13:29:35+08:00\"///分账完成时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询分账结果",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"orders",
+										"{{此处替换为要查询的商家分账单号}}"
+									],
+									"query": [
+										{
+											"key": null,
+											"value": ""
+										},
+										{
+											"key": "transaction_id",
+											"value": "4208450740201411110007820472",
+											"description": "要查询分账的微信支付订单号"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"orders",
+												"{{此处替换为要查询的商家分账单号}}"
+											],
+											"query": [
+												{
+													"key": null,
+													"value": null
+												},
+												{
+													"key": "transaction_id",
+													"value": "4208450740201411110007820472",
+													"description": "要查询分账的微信支付订单号"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 注意：查询分账结果时，传参申请分账时的商户分账单号； 查询分账完结执行的结果，传参发起分账完结时的商户分账单号。 */\n{\n  \"transaction_id\": \"4208450740201411110007820472\",///发起分账的微信支付订单号\n  \"out_order_no\": \"P2022111111111100011\",///商户发起分账请求的系统内部单号\n  \"order_id\": \"3008450740201411110007820472\",///微信分账单号，微信支付系统返回的唯一标识\n  \"state\": \"FINISHED\",///分账单状态（每个接收方的分账结果请查看receivers中的result字段），枚举值： 1、PROCESSING：处理中 2、FINISHED：分账完成\n  \"receivers\": [\n    {\n      \"amount\": 888, ///分账金额，单位为分\n      \"description\": \"分给商户A\",///分账描述，该字段为商户传参\n      \"type\": \"MERCHANT_ID\",//////分账接收方类型，枚举值：1、MERCHANT_ID：商户号 2、PERSONAL_OPENID\n      \"account\": \"1900000109\",//////分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n      \"result\": \"SUCCESS\", ///分账结果，枚举值：1、PENDING：待分账 2、SUCCESS：分账成功 3、CLOSED：已关闭\n      \"fail_reason\": \"ACCOUNT_ABNORMAL\", /* 分账失败原因，当分账结果result为CLOSED（已关闭）时，返回该字段 枚举值：\n        1、ACCOUNT_ABNORMAL：分账接收账户异常   2、NO_RELATION：分账关系已解除  3、RECEIVER_HIGH_RISK：高风险接收方 4、RECEIVER_REAL_NAME_NOT_VERIFIED：接收方未实名\n        5、NO_AUTH：分账权限已解除  6、RECEIVER_RECEIPT_LIMIT：接收方已达收款限额   7、PAYER_ACCOUNT_ABNORMAL：分出方账户异常 */\n      \"detail_id\": \"36011111111111111111111\", ///微信分账明细单号，每笔分账业务执行的明细单号，可与资金账单对账使用\n      \"create_time\": \"2015-05-20T13:29:35+08:00\",///分账创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n      \"finish_time\": \"2015-05-20T13:29:35+08:00\"///分账完成时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "请求分账回退",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_3.shtml\n   接口说明：如果订单已经分账，在退款时，可以先调此接口，将已分账的资金从分账接收方的账户回退给分账方，再发起退款。\n   注意：\n    1、分账回退以原分账单为依据，支持多次回退，申请回退总金额不能超过原分账单分给该接收方的金额。\n    2、此接口采用同步处理模式，即在接收到商户请求后，会实时返回处理结果。\n    3、对同一个分账接收方最多能发起20次分账回退请求。\n    4、退款和分账回退没有耦合，分账回退可以先于退款请求，也可以后于退款请求。\n    5、此功能需要接收方访问商户平台-交易中心-分账-分账接收设置，开启同意分账回退后，才能使用。\n    6、不支持针对“分账到零钱”的分账单发起分账回退。\n    7、分账回退的时限是180天。 */\n{\n  \"order_id\": \"3008450740201411110007820472\",///微信分账单号，微信支付系统返回的唯一标识。微信分账单号与商户分账单号二选一传参\n  \"out_return_no\": \"R20190516001\",///商户分账回退单号，此回退单号是商户在自己后台生成的一个新的回退单号，需要在商户号下唯一\n  \"return_mchid\": \"86693852\",///回退商户号，发起分账时，分账接口传参中的分账接收方商户号\n  \"amount\": 10,///需要从分账接收方回退的金额，单位为“分”，只能为整数，不能超过原始分账单分出给该接收方的金额\n  \"description\": \"用户退款\" ///分账回退的原因描述\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/return-orders",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"return-orders"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_3.shtml\n   接口说明：如果订单已经分账，在退款时，可以先调此接口，将已分账的资金从分账接收方的账户回退给分账方，再发起退款。\n   注意：\n    1、分账回退以原分账单为依据，支持多次回退，申请回退总金额不能超过原分账单分给该接收方的金额。\n    2、此接口采用同步处理模式，即在接收到商户请求后，会实时返回处理结果。\n    3、对同一个分账接收方最多能发起20次分账回退请求。\n    4、退款和分账回退没有耦合，分账回退可以先于退款请求，也可以后于退款请求。\n    5、此功能需要接收方访问商户平台-交易中心-分账-分账接收设置，开启同意分账回退后，才能使用。\n    6、不支持针对“分账到零钱”的分账单发起分账回退。\n    7、分账回退的时限是180天。 */\n{\n  \"order_id\": \"3008450740201411110007820472\",///微信分账单号，微信支付系统返回的唯一标识。微信分账单号与商户分账单号二选一传参\n  \"out_return_no\": \"R20190516001\",///商户分账回退单号，此回退单号是商户在自己后台生成的一个新的回退单号，需要在商户号下唯一\n  \"return_mchid\": \"86693852\",///回退商户号，发起分账时，分账接口传参中的分账接收方商户号\n  \"amount\": 10,///需要从分账接收方回退的金额，单位为“分”，只能为整数，不能超过原始分账单分出给该接收方的金额\n  \"description\": \"用户退款\" ///分账回退的原因描述\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/return-orders",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"return-orders"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"order_id\": \"3008450740201411110007820472\", ///微信分账单号，微信支付系统返回的唯一标识。\n  \"out_order_no\": \"P20150806125346\",///商户分账单号,商户自己生成的分账单号\n  \"out_return_no\": \"R20190516001\",///商户发起分账回退时自己生成的单号\n  \"return_id\": \"3008450740201411110007820472\",///由微信生成的分账回退单号，微信支付系统返回的唯一标识\n  \"return_mchid\": \"86693852\",///回退商户号，\n  \"amount\": 10,///回退金额，单位为“分”\n  \"description\": \"用户退款\",///分账回退的原因\n  \"result\": \"SUCCESS\",/* 分账回退结果\n    如果请求返回为处理中，则商户可以通过调用回退结果查询接口获取请求的最终处理结果。如果查询到回退结果在处理中，请勿变更商户回退单号，使用相同的参数再次发起分账回退，否则会出现资金风险。在处理中状态的回退单如果5天没有成功，会因为超时被设置为已失败。枚举值：PROCESSING：处理中 SUCCESS：已成功 FAILED：已失败 */\n  \"fail_reason\": \"TIME_OUT_CLOSED\", ///分账回退失败原因。包含以下枚举值：ACCOUNT_ABNORMAL：原分账接收方账户异常 TIME_OUT_CLOSED：超时关单 PAYER_ACCOUNT_ABNORMAL：原分账分出方账户异常\n  \"create_time\": \"2022-11-11T13:29:35+08:00\",///分账回退创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"finish_time\": \"2022-11-11T13:39:35+08:00\"///分账回退完成时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "查询分账回退结果",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/return-orders/{{此处替换为要查询的商家分账回退单号}}?&out_order_no=P2022111111111100011",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"return-orders",
+										"{{此处替换为要查询的商家分账回退单号}}"
+									],
+									"query": [
+										{
+											"key": null,
+											"value": ""
+										},
+										{
+											"key": "out_order_no",
+											"value": "P2022111111111100011",
+											"description": "原发起分账请求时使用的商户系统内部的分账单号"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/return-orders/{{此处替换为要查询的商家分账回退单号}}?&out_order_no=P2022111111111100011",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"return-orders",
+												"{{此处替换为要查询的商家分账回退单号}}"
+											],
+											"query": [
+												{
+													"key": null,
+													"value": null
+												},
+												{
+													"key": "out_order_no",
+													"value": "P2022111111111100011",
+													"description": "原发起分账请求时使用的商户系统内部的分账单号"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"order_id\": \"3008450740201411110007820472\", ///微信分账单号，微信支付系统返回的唯一标识。\n  \"out_order_no\": \"P2022111111111100011\",///商户分账单号,商户自己生成的分账单号\n  \"out_return_no\": \"R20190516001\",///商户发起分账回退时自己生成的单号\n  \"return_id\": \"3008450740201411110007820472\",///由微信生成的分账回退单号，微信支付系统返回的唯一标识\n  \"return_mchid\": \"86693852\",///回退商户号，\n  \"amount\": 10,///回退金额，单位为“分”\n  \"description\": \"用户退款\",///分账回退的原因\n  \"result\": \"SUCCESS\",/* 分账回退结果\n    如果请求返回为处理中，则商户可以通过调用回退结果查询接口获取请求的最终处理结果。如果查询到回退结果在处理中，请勿变更商户回退单号，使用相同的参数再次发起分账回退，否则会出现资金风险。在处理中状态的回退单如果5天没有成功，会因为超时被设置为已失败。枚举值：PROCESSING：处理中 SUCCESS：已成功 FAILED：已失败 */\n  \"fail_reason\": \"TIME_OUT_CLOSED\", ///分账回退失败原因。包含以下枚举值：ACCOUNT_ABNORMAL：原分账接收方账户异常 TIME_OUT_CLOSED：超时关单 PAYER_ACCOUNT_ABNORMAL：原分账分出方账户异常\n  \"create_time\": \"2022-11-11T13:29:35+08:00\",///分账回退创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"finish_time\": \"2022-11-11T13:39:35+08:00\"///分账回退完成时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
+						},
+						{
+							"name": "解冻剩余资金",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_4.shtml\n   接口说明：不需要进行分账的订单，可直接调用本接口将订单的金额全部解冻给本商户\n   注意事项：\n   1、调用分账接口后，需要解冻剩余资金时，调用本接口将剩余的分账金额全部解冻给本商户\n   2、此接口采用异步处理模式，即在接收到商户请求后，优先受理请求再异步处理，最终的分账结果可以通过查询分账接口获取\n   3、为什么我请求成功该接口后资金未解冻？此问题请检查out_order_no参数，如果单号重复使用无法解冻，你可以将完结分账也视为一笔分账交易，该笔分账交易是将剩余资金转给分账方 */\n{\n  \"transaction_id\": \"4208450740201411110007820472\",///要解冻的微信支付订单号\n  \"out_order_no\": \"P20150806125346\",///商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@\n  \"description\": \"解冻全部剩余资金\" ///分账的原因描述，分账账单中需要体现\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/orders/unfreeze",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"orders",
+										"unfreeze"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_4.shtml\n   接口说明：不需要进行分账的订单，可直接调用本接口将订单的金额全部解冻给本商户\n   注意事项：\n   1、调用分账接口后，需要解冻剩余资金时，调用本接口将剩余的分账金额全部解冻给本商户\n   2、此接口采用异步处理模式，即在接收到商户请求后，优先受理请求再异步处理，最终的分账结果可以通过查询分账接口获取\n   3、为什么我请求成功该接口后资金未解冻？此问题请检查out_order_no参数，如果单号重复使用无法解冻，你可以将完结分账也视为一笔分账交易，该笔分账交易是将剩余资金转给分账方 */\n{\n  \"transaction_id\": \"4208450740201411110007820472\",///要解冻的微信支付订单号\n  \"out_order_no\": \"P20150806125346\",///商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@\n  \"description\": \"解冻全部剩余资金\" ///分账的原因描述，分账账单中需要体现\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/orders/unfreeze",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"orders",
+												"unfreeze"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 注意：查询分账结果时，传参申请分账时的商户分账单号； 查询分账完结执行的结果，传参发起分账完结时的商户分账单号。 */\n{\n  \"transaction_id\": \"4208450740201411110007820472\",///发起分账的微信支付订单号\n  \"out_order_no\": \"P2022111111111100011\",///商户发起分账请求的系统内部单号\n  \"order_id\": \"3008450740201411110007820472\",///微信分账单号，微信支付系统返回的唯一标识\n  \"state\": \"FINISHED\",///分账单状态（每个接收方的分账结果请查看receivers中的result字段），枚举值： 1、PROCESSING：处理中 2、FINISHED：分账完成\n  \"receivers\": [\n    {\n      \"amount\": 888, ///分账金额，单位为分\n      \"description\": \"分给商户A\",///分账描述，该字段为商户传参\n      \"type\": \"MERCHANT_ID\",//////分账接收方类型，枚举值：1、MERCHANT_ID：商户号 2、PERSONAL_OPENID\n      \"account\": \"1900000109\",//////分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n      \"result\": \"SUCCESS\", ///分账结果，枚举值：1、PENDING：待分账 2、SUCCESS：分账成功 3、CLOSED：已关闭\n      \"fail_reason\": \"ACCOUNT_ABNORMAL\", /* 分账失败原因，当分账结果result为CLOSED（已关闭）时，返回该字段 枚举值：\n        1、ACCOUNT_ABNORMAL：分账接收账户异常   2、NO_RELATION：分账关系已解除  3、RECEIVER_HIGH_RISK：高风险接收方 4、RECEIVER_REAL_NAME_NOT_VERIFIED：接收方未实名\n        5、NO_AUTH：分账权限已解除  6、RECEIVER_RECEIPT_LIMIT：接收方已达收款限额   7、PAYER_ACCOUNT_ABNORMAL：分出方账户异常 */\n      \"detail_id\": \"36011111111111111111111\", ///微信分账明细单号，每笔分账业务执行的明细单号，可与资金账单对账使用\n      \"create_time\": \"2015-05-20T13:29:35+08:00\",///分账创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n      \"finish_time\": \"2015-05-20T13:29:35+08:00\"///分账完成时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    }\n  ]\n}"
+								}
+							]
+						},
+						{
+							"name": "查询剩余待分金额",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/transactions/{{请将此处替换为要查询剩余待分金额的微信支付订单号}}/amounts",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"transactions",
+										"{{请将此处替换为要查询剩余待分金额的微信支付订单号}}",
+										"amounts"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/transactions/{{请将此处替换为要查询剩余待分金额的微信支付订单号}}/amounts",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"transactions",
+												"{{请将此处替换为要查询剩余待分金额的微信支付订单号}}",
+												"amounts"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"transaction_id\": \"4208450740201411110007820472\",///微信支付订单号\n  \"unsplit_amount\": 1000 ///订单剩余待分金额，整数，单元为\"分\"\n}"
+								}
+							]
+						},
+						{
+							"name": "添加分账接收方",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_8.shtml\n   接口说明：商户发起添加分账接收方请求，建立分账接收方列表。后续可通过发起分账请求，将分账方商户结算后的资金，分到该分账接收方\n   注意：商户需确保向微信支付传输用户身份信息和账号标识信息做一致性校验已合法征得用户授权 */\n{\n  \"appid\": \"wx8888888888888888\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n  \"relation_type\": \"CUSTOM\",\n  /*商户与接收方的关系。 本字段值为枚举：STORE：门店 STAFF：员工 STORE_OWNER：店主 PARTNER：合作伙伴 HEADQUARTER：总部 BRAND：品牌方 DISTRIBUTOR：分销商\n    USER：用户 SUPPLIER： 供应商 CUSTOM：自定义 */\n  \"custom_relation\": \"代理商\"///商户与接收方具体的关系，本字段最多10个字。当字段relation_type的值为CUSTOM时，本字段必填;当字段relation_type的值不为CUSTOM时，本字段无需填写。\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/receivers/add",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"receivers",
+										"add"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/receivers/add",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"receivers",
+												"add"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"86693852\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n  \"relation_type\": \"CUSTOM\",\n  /*商户与接收方的关系。 本字段值为枚举：STORE：门店 STAFF：员工 STORE_OWNER：店主 PARTNER：合作伙伴 HEADQUARTER：总部 BRAND：品牌方 DISTRIBUTOR：分销商\n    USER：用户 SUPPLIER： 供应商 CUSTOM：自定义 */\n  \"custom_relation\": \"代理商\"///商户与接收方具体的关系，当字段relation_type的值为CUSTOM时，本字段会返回\n}"
+								}
+							]
+						},
+						{
+							"name": "删除分账接收方",
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_9.shtml\n   接口说明：商户发起删除分账接收方请求。删除后，不支持将分账方商户结算后的资金，分到该分账接收方 */\n{\n  \"appid\": \"{{appid}}\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"1900000109\"///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/receivers/delete",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"receivers",
+										"delete"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/receivers/delete",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"receivers",
+												"delete"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"1900000109\"///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n}"
+								}
+							]
+						},
+						{
+							"name": "申请分账账单",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/profitsharing/bills?bill_date=2022-11-11",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"profitsharing",
+										"bills"
+									],
+									"query": [
+										{
+											"key": "bill_date",
+											"value": "2022-11-11",
+											"description": "格式yyyy-MM-DD 仅支持三个月内的账单下载申请。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/profitsharing/bills?bill_date=2022-11-11",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"profitsharing",
+												"bills"
+											],
+											"query": [
+												{
+													"key": "bill_date",
+													"value": "2022-11-11",
+													"description": "格式yyyy-MM-DD 仅支持三个月内的账单下载申请。"
+												}
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"download_url\": \"https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO\", ///账单下载地址\n    \"hash_type\": \"SHA1\", ///哈希类型\t\n    \"hash_value\": \"8823044c286bea726f149bfcfce0b0318122d755\" ///哈希值\t\n}"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "风险合规",
+			"item": [
+				{
+					"name": "消费者投诉2.0",
+					"item": [
+						{
+							"name": "查询投诉单列表",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2?limit=5&offset=10&begin_date=2022-11-01&end_date=2022-11-11&complainted_mchid={{mchid}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaints-v2"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "5",
+											"description": "设置该次请求返回的最大投诉条数，范围【1,50】,商户自定义字段，不传默认为10。\n注：如遇到提示“当前查询结果数据量过大”，是回包触发微信支付下行数据包大小限制，请缩小入参limit并重试。"
+										},
+										{
+											"key": "offset",
+											"value": "10",
+											"description": "该次请求的分页开始位置，从0开始计数，例如offset=10，表示从第11条记录开始返回，不传默认为0 。"
+										},
+										{
+											"key": "begin_date",
+											"value": "2022-11-01",
+											"description": "投诉发生的开始日期，格式为yyyy-MM-DD。注意，查询日期跨度不超过30天，当前查询为实时查询"
+										},
+										{
+											"key": "end_date",
+											"value": "2022-11-11",
+											"description": "投诉发生的结束日期，格式为yyyy-MM-DD。注意，查询日期跨度不超过30天，当前查询为实时查询"
+										},
+										{
+											"key": "complainted_mchid",
+											"value": "{{mchid}}",
+											"description": "投诉单对应的被诉商户号。示例值：1900012181"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2?limit=5&offset=10&begin_date=2022-11-01&end_date=2022-11-11&complainted_mchid={{mchid}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaints-v2"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "5",
+													"description": "设置该次请求返回的最大投诉条数，范围【1,50】,商户自定义字段，不传默认为10。\n注：如遇到提示“当前查询结果数据量过大”，是回包触发微信支付下行数据包大小限制，请缩小入参limit并重试。"
+												},
+												{
+													"key": "offset",
+													"value": "10",
+													"description": "该次请求的分页开始位置，从0开始计数，例如offset=10，表示从第11条记录开始返回，不传默认为0 。"
+												},
+												{
+													"key": "begin_date",
+													"value": "2022-11-01",
+													"description": "投诉发生的开始日期，格式为yyyy-MM-DD。注意，查询日期跨度不超过30天，当前查询为实时查询"
+												},
+												{
+													"key": "end_date",
+													"value": "2022-11-11",
+													"description": "投诉发生的结束日期，格式为yyyy-MM-DD。注意，查询日期跨度不超过30天，当前查询为实时查询"
+												},
+												{
+													"key": "complainted_mchid",
+													"value": "{{mchid}}",
+													"description": "投诉单对应的被诉商户号。示例值：1900012181"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 参数说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_11.shtml */\n{\n  \"data\": [\n    {\n      \"complaint_id\": \"200201820200101080076610000\",\n      \"complaint_time\": \"2015-05-20T13:29:35.120+08:00\",\n      \"complaint_detail\": \"反馈一个重复扣费的问题\",\n      \"complaint_state\": \"PENDING\",\n      \"payer_phone\": \"Qe41VhP/sGdNeTHMQGlxCWiUyHu6XNO9GCYln2Luv4HhwJzZBfcL12sB+PgZcS5NhePBog30NgJ1xRaK+gbGDKwpg==\",\n      \"complaint_order_info\":[\n          {\n            \"transaction_id\": \"4200000404201909069117582536\",\n            \"out_trade_no\": \"20190906154617947762231\",\n            \"amount\": 3\n          }\n      ],\n      \"service_order_info\": [\n         {\n\t   \"order_id\": \"15646546545165651651\",\n\t   \"out_order_no\": \"1234323JKHDFE1243252\",\n\t   \"state\": \"DOING\" \n\t      }\n      ],\n      \"complaint_full_refunded\": true,\n      \"incoming_user_response\": true,\n      \"user_complaint_times\": 1,\n      \"complaint_media_list\": [\n\t      {\n\t\t\t\"media_type\": \"USER_COMPLAINT_IMAGE\",\n\t\t\t\"media_url\": [\n\t\t\t\t\"https://api.mch.weixin.qq.com/v3/merchant-service/images/xxxxx\"\n\t\t\t]\n\t\t  }\n\t  ],\n  \t \"problem_description\": \"不满意商家服务\",\n  \t \"limit\": 5,\n  \t \"offset\": 10,\n  \t \"total_count\": 1000\n  \n}"
+								}
+							]
+						},
+						{
+							"name": "查询投诉单详情",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaints-v2",
+										"{{请将此处替换为要查询的投诉单对应的投诉单号}}"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaints-v2",
+												"{{请将此处替换为要查询的投诉单对应的投诉单号}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 参数说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_13.shtml */\n{\n\t\"complaint_id\": \"200201820200101080076610000\",\n\t\"complaint_time\": \"2015-05-20T13:29:35.120+08:00\",\n\t\"complaint_detail\": \"反馈一个重复扣费的问题\",\n\t\"complainted_mchid\": 1900012181,\n\t\"complaint_state\": \"PENDING\",\n\t\"payer_phone\": \"sGdNeTHMQGlxCWiUyHu6XNO9GCYln2Luv4HhwJzZBfcL12sB\",\n\t\"payer_openid\": \"oUpF8uMuAJO_M2pxb1Q9zNjWeS6o\",\n\t\"complaint_media_list\": [{\n\t\t\"media_type\": \"USER_COMPLAINT_IMAGE\",\n\t\t\"media_url\": [\n\t\t\t\"https://api.mch.weixin.qq.com/v3/merchant-service/images/xxxxx\"\n\t\t]\n\t}],\n\t\"complaint_order_info\": [{\n\t\t\"transaction_id\": \"4200000404201909069117582536\",\n\t\t\"out_trade_no\": \"20190906154617947762231\",\n\t\t\"amount\": 3\n\t}],\n   \"service_order_info\": [\n    {\n\t   \"order_id\": \"15646546545165651651\",\n\t   \"out_order_no\": \"1234323JKHDFE1243252\",\n\t   \"state\": \"DOING\" \n\t}\n  ]\n\t\"complaint_full_refunded\": true,\n\t\"incoming_user_response\": true,\n\t\"problem_description\": \"不满意商家服务\",\n\t\"user_complaint_times\": 1\n}"
+								}
+							]
+						},
+						{
+							"name": "查询投诉协商历史",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}/negotiation-historys?limit=50&offset=0",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaints-v2",
+										"{{请将此处替换为要查询的投诉单对应的投诉单号}}",
+										"negotiation-historys"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "50",
+											"description": "设置该次请求返回的最大协商历史条数，范围[1,300]，不传默认为100。\n注：如遇到提示“当前查询结果数据量过大”，是回包触发微信支付下行数据包大小限制，请缩小入参limit并重试。"
+										},
+										{
+											"key": "offset",
+											"value": "0",
+											"description": "该次请求的分页开始位置，从0开始计数，例如offset=10，表示从第11条记录开始返回，不传默认为0。。"
+										}
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}/negotiation-historys?limit=50&offset=0",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaints-v2",
+												"{{请将此处替换为要查询的投诉单对应的投诉单号}}",
+												"negotiation-historys"
+											],
+											"query": [
+												{
+													"key": "limit",
+													"value": "50",
+													"description": "设置该次请求返回的最大协商历史条数，范围[1,300]，不传默认为100。\n注：如遇到提示“当前查询结果数据量过大”，是回包触发微信支付下行数据包大小限制，请缩小入参limit并重试。"
+												},
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "该次请求的分页开始位置，从0开始计数，例如offset=10，表示从第11条记录开始返回，不传默认为0。。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 参数说明看文档: https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_12.shtml */\n{\n\t\"data\": [{\n\t\t\"complaint_media_list\": {\n\t\t\t\"media_type\": \"USER_COMPLAINT_IMAGE\",\n\t\t\t\"media_url\": [\n\t\t\t\t\"https://api.mch.weixin.qq.com/v3/merchant-service/images/xxxxx\"\n\t\t\t]\n\t\t},\n\t\t\"log_id\": \"300285320210322170000071077\",\n\t\t\"operator\": \"投诉人\",\n\t\t\"operate_time\": \"2015-05-20T13:29:35.120+08:00\",\n\t\t\"operate_type\": \"USER_CREATE_COMPLAINT\",\n\t\t\"operate_details\": \"已与用户电话沟通解决\",\n\t\t\"image_list\": [\n\t\t\t\"https://qpic.cn/xxx\"\n\t\t]\n\t}],\n\t\"limit\": 50,\n\t\"offset\": 50,\n\t\"total_count\": 1000\n}"
+								}
+							]
+						},
+						{
+							"name": "创建投诉通知回调地址",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_12.shtml\n   接口说明：商户通过调用此接口创建投诉通知回调URL，当用户产生新投诉且投诉状态已变更时，微信支付会通过回调URL通知商户。对于服务商、渠道商，会收到所有子商户的投诉信息推送。 */\n{\n   \"url\": \"https://www.pay.weixin.qq.com/notify\" ///接收投诉回调通知地址，仅支持https。\n} ",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaint-notifications"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_12.shtml\n   接口说明：商户通过调用此接口创建投诉通知回调URL，当用户产生新投诉且投诉状态已变更时，微信支付会通过回调URL通知商户。对于服务商、渠道商，会收到所有子商户的投诉信息推送。 */\n{\n   \"url\": \"https://www.pay.weixin.qq.com/notify\" ///接收投诉回调通知地址，仅支持https。\n} ",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaint-notifications"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"mchid\": \"1900012181\", ///返回创建回调地址的商户号\n  \"url\": \"https://www.pay.weixin.qq.com/notify\" ///配置的接收投诉回调通知地址\n}"
+								}
+							]
+						},
+						{
+							"name": "查询投诉通知回调地址",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaint-notifications"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaint-notifications"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"mchid\": \"1900012181\", ///返回创建回调地址的商户号\n  \"url\": \"https://www.pay.weixin.qq.com/notify\" ///配置的接收投诉回调通知地址\n}"
+								}
+							]
+						},
+						{
+							"name": "更新投诉通知回调地址",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_4.shtml\n   接口说明：商户通过调用此接口更新投诉通知的回调URL。 */\n{\n   \"url\": \"https://www.pay.weixin.qq.com/notify\" ///配置更新的接收投诉回调通知地址\n} ",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaint-notifications"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_4.shtml\n   接口说明：商户通过调用此接口更新投诉通知的回调URL。 */\n{\n   \"url\": \"https://www.pay.weixin.qq.com/notify\" ///配置更新的接收投诉回调通知地址\n} ",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaint-notifications"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"mchid\": \"1900012181\", ///返回创建回调地址的商户号\n  \"url\": \"https://www.pay.weixin.qq.com/notify\" ///配置的接收投诉回调通知地址\n}"
+								}
+							]
+						},
+						{
+							"name": "删除投诉通知回调地址",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaint-notifications"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaint-notifications"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "回复用户",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_14.shtml\n   接口说明：商户可通过调用此接口，提交内容回复用户。其中上传图片凭证需首先调用商户上传反馈图片接口，得到图片id，再将id填入请求。 回复可配置文字链，传入跳转链接文案和跳转链接字段，用户点击即可跳转对应页面。首次回复用户后，投诉单状态将由待处理更新为处理中。 */\n{\n  \"complainted_mchid\": \"{{mchid}}\",///投诉单对应的被诉商户号\n  \"response_content\": \"已与用户沟通解决\",///具体的投诉处理方案，限制200个字符以内。\n  \"jump_url\": \"https://www.xxx.com/notify\",/* 商户可在回复中附加跳转链接，引导用户跳转至商户客诉处理页面，链接需满足https格式 注：配置文字链属于灰度功能, 若有需要请使用超管邮箱，按照要求发送邮件申请。邮件要求详情见：https://kf.qq.com/faq/211207a6zMBj211207ZnIr2A.html  */\n  \"jump_url_text\": \"查看订单详情\", ///际展示给用户的文案，附在回复内容之后。用户点击文案，即可进行跳转。注:若传入跳转链接，则跳转链接文案为必传项，二者缺一不可。\n  \"response_images\": [\"aabbccdd\",\"aaccddee\"] ///传入调用商户上传反馈图片接口返回的media_id，最多上传4张图片凭证\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要回复的投诉单对应的投诉单号}}/response",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaints-v2",
+										"{{请将此处替换为要回复的投诉单对应的投诉单号}}",
+										"response"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_14.shtml\n   接口说明：商户可通过调用此接口，提交内容回复用户。其中上传图片凭证需首先调用商户上传反馈图片接口，得到图片id，再将id填入请求。 回复可配置文字链，传入跳转链接文案和跳转链接字段，用户点击即可跳转对应页面。首次回复用户后，投诉单状态将由待处理更新为处理中。 */\n{\n  \"complainted_mchid\": \"{{mchid}}\",///投诉单对应的被诉商户号\n  \"response_content\": \"已与用户沟通解决\",///具体的投诉处理方案，限制200个字符以内。\n  \"jump_url\": \"https://www.xxx.com/notify\",/* 商户可在回复中附加跳转链接，引导用户跳转至商户客诉处理页面，链接需满足https格式 注：配置文字链属于灰度功能, 若有需要请使用超管邮箱，按照要求发送邮件申请。邮件要求详情见：https://kf.qq.com/faq/211207a6zMBj211207ZnIr2A.html  */\n  \"jump_url_text\": \"查看订单详情\", ///际展示给用户的文案，附在回复内容之后。用户点击文案，即可进行跳转。注:若传入跳转链接，则跳转链接文案为必传项，二者缺一不可。\n  \"response_images\": [\"aabbccdd\",\"aaccddee\"] ///传入调用商户上传反馈图片接口返回的media_id，最多上传4张图片凭证\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要回复的投诉单对应的投诉单号}}/response",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaints-v2",
+												"{{请将此处替换为要回复的投诉单对应的投诉单号}}",
+												"response"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "反馈处理完成",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"complainted_mchid\": \"{{mchid}}\"///投诉单对应的被诉商户号\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为反馈处理完成的投诉单号}}/complete",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaints-v2",
+										"{{此处替换为反馈处理完成的投诉单号}}",
+										"complete"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"complainted_mchid\": \"{{mchid}}\"///投诉单对应的被诉商户号\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为反馈处理完成的投诉单号}}/complete",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaints-v2",
+												"{{此处替换为反馈处理完成的投诉单号}}",
+												"complete"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "更新退款审批结果",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_19.shtml\n   接口说明：商户可通过调用此接口，更新“申请退款”单据的退款审批结果。\n   注意：针对“申请退款单”，需要商户明确返回是否可退款的审批结果。\n    1、核实可以退款，审批动作传入“APPROVE”，同意退款，并给出一个预计退款时间。传入“同意退款”后，需要额外调退款接口发起原路退款。退款到账后，投诉单的状态将自动扭转为“处理完成”。\n    2、核实不可退款，审批动作传入“REJECT”，拒绝退款，并说明拒绝退款原因。驳回退款后，投诉单的状态将自动扭转为“处理完成”。请确保和用户沟通清楚后再驳回，避免用户重复投诉。 */\n{\n  \"action\": \"REJECT\", ///审批动作 同意 或 拒绝 REJECT：拒绝，拒绝退款 APPROVE：同意，同意退款\n  \"launch_refund_day\": 3, ///在同意退款时返回，预计将在多少个工作日内能发起退款, 0代表当天\n  \"reject_media_list\": [\"aabbccdd\",\"aaccddee\"], ///在拒绝退款时，如果有拒绝的图片举证，可以提供 最多上传4张图片, 传入调用“商户上传反馈图片”接口返回的media_id，最多上传4张图片凭证\n  \"reject_reason\": \"拒绝退款\",///在拒绝退款时返回拒绝退款的原因\n  \"remark\": \"不同意退款\" ///任何需要向微信支付客服反馈的信息\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为投诉单对应的投诉单号}}/update-refund-progress",
+									"host": [
+										"{{endpoint}}"
+									],
+									"path": [
+										"v3",
+										"merchant-service",
+										"complaints-v2",
+										"{{此处替换为投诉单对应的投诉单号}}",
+										"update-refund-progress"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "204_无数据",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_19.shtml\n   接口说明：商户可通过调用此接口，更新“申请退款”单据的退款审批结果。\n   注意：针对“申请退款单”，需要商户明确返回是否可退款的审批结果。\n    1、核实可以退款，审批动作传入“APPROVE”，同意退款，并给出一个预计退款时间。传入“同意退款”后，需要额外调退款接口发起原路退款。退款到账后，投诉单的状态将自动扭转为“处理完成”。\n    2、核实不可退款，审批动作传入“REJECT”，拒绝退款，并说明拒绝退款原因。驳回退款后，投诉单的状态将自动扭转为“处理完成”。请确保和用户沟通清楚后再驳回，避免用户重复投诉。 */\n{\n  \"action\": \"REJECT\", ///审批动作 同意 或 拒绝 REJECT：拒绝，拒绝退款 APPROVE：同意，同意退款\n  \"launch_refund_day\": 3, ///在同意退款时返回，预计将在多少个工作日内能发起退款, 0代表当天\n  \"reject_media_list\": [\"aabbccdd\",\"aaccddee\"], ///在拒绝退款时，如果有拒绝的图片举证，可以提供 最多上传4张图片, 传入调用“商户上传反馈图片”接口返回的media_id，最多上传4张图片凭证\n  \"reject_reason\": \"拒绝退款\",///在拒绝退款时返回拒绝退款的原因\n  \"remark\": \"不同意退款\" ///任何需要向微信支付客服反馈的信息\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为投诉单对应的投诉单号}}/update-refund-progress",
+											"host": [
+												"{{endpoint}}"
+											],
+											"path": [
+												"v3",
+												"merchant-service",
+												"complaints-v2",
+												"{{此处替换为投诉单对应的投诉单号}}",
+												"update-refund-progress"
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "Text",
+									"header": [],
+									"cookie": [],
+									"body": ""
+								}
+							]
 						}
 					]
 				}
@@ -289,6 +8800,7 @@
 			"script": {
 				"type": "text/javascript",
 				"exec": [
+					"/* global pm, require, console, forge, SM2Lib */",
 					"const forge_code = pm.collectionVariables.get(\"forge_code\");",
 					"(new Function(forge_code))();",
 					"",
@@ -549,10 +9061,10 @@
 					"  url = new sdk.Url(resolvedRequest.url),",
 					"  canonicalUrl = url.getPathWithQuery();",
 					"",
-					"const method = request.method;",
+					"const method = pm.request.method;",
 					"",
 					"let body = \"\";",
-					"if (method === \"POST\" || method === \"PUT\" || method === \"PATCH\") {",
+					"if (!pm.request.body.isEmpty() && (method === \"POST\" || method === \"PUT\" || method === \"PATCH\")) {",
 					"  // 使用变量替换后的body",
 					"  body = resolvedRequest.body.raw;",
 					"  if (canonicalUrl.endsWith(\"upload\")) {",
@@ -578,18 +9090,20 @@
 					"  body +",
 					"  \"\\n\";",
 					"",
+					"console.log(`sign message=[${message}]`);",
+					"",
 					"let auth;",
 					"const enableShangMi = pm.environment.get(\"shangmi\");",
 					"if (enableShangMi == \"true\") {",
 					"  console.log(\"using ShangMi for signature\");",
 					"",
 					"  const sm2js_code = pm.collectionVariables.get(\"sm2js_code\");",
-					"  (new Function(sm2_code))();",
+					"  (new Function(sm2js_code))();",
 					"",
-					"  const mchid = pm.environment.get(\"merchantId\");",
-					"  const serialNumber = pm.environment.get(\"merchantSerialNo\");",
+					"  const mchid = pm.environment.get(\"mchid\");",
+					"  const serialNumber = pm.environment.get(\"merchant_serial_no\");",
 					"  // 二进制的私钥和公钥",
-					"  const privateKeyPem = pm.environment.get(\"merchantPrivateKey\");",
+					"  const privateKeyPem = pm.environment.get(\"apiclient_key.pem\");",
 					"  const publicKeyPem = pm.environment.get(\"merchantPublicKey\");",
 					"",
 					"  const privateKeyInfo = privateKeyFromPem(privateKeyPem);",
@@ -610,10 +9124,10 @@
 					"} else {",
 					"  console.log(\"using RSA for signature\");",
 					"",
-					"  const mchid = pm.environment.get(\"merchantId\");",
-					"  const serialNo = pm.environment.get(\"merchantSerialNo\");",
+					"  const mchid = pm.environment.get(\"mchid\");",
+					"  const serialNo = pm.environment.get(\"merchant_serial_no\");",
 					"  // pem私钥字符串",
-					"  const privateKeyStr = pm.environment.get(\"merchantPrivateKey\");",
+					"  const privateKeyStr = pm.environment.get(\"apiclient_key.pem\");",
 					"  // 从pem中加载私钥",
 					"  const privateKey = forge.pki.privateKeyFromPem(privateKeyStr);",
 					"",
@@ -627,8 +9141,7 @@
 					"pm.request.headers.add({",
 					"  key: \"Authorization\",",
 					"  value: auth,",
-					"});",
-					""
+					"});"
 				]
 			}
 		},

--- a/wechatpay-apiv3.postman_collection.json
+++ b/wechatpay-apiv3.postman_collection.json
@@ -8221,11 +8221,8 @@
 						},
 						{
 							"name": "添加分账接收方",
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
 										"key": "Wechatpay-Serial",

--- a/wechatpay-apiv3.postman_collection.json
+++ b/wechatpay-apiv3.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "404c1bb2-b585-42d0-ab2b-07d2ab60630c",
+		"_postman_id": "efe705f2-fba8-4d3a-b11b-eea043018023",
 		"name": "微信支付 APIv3",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "15520576"
@@ -15,9 +15,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{endpoint}}/v3/certificates",
+							"raw": "{{server_url}}/v3/certificates",
 							"host": [
-								"{{endpoint}}"
+								"{{server_url}}"
 							],
 							"path": [
 								"v3",
@@ -39,9 +39,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{endpoint}}/v3/certificates",
+									"raw": "{{server_url}}/v3/certificates",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -142,9 +142,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+									"raw": "{{server_url}}/v3/pay/transactions/jsapi",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -161,9 +161,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+											"raw": "{{server_url}}/v3/pay/transactions/jsapi",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -174,7 +174,7 @@
 										}
 									},
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"prepay_id\": \"wx042120326484513d5ff2fe243d766e0000\"\n    /* 预支付交易会话标识。用于后续接口调用中使用，该值有效期为2小时 */\n}"
 								}
@@ -186,9 +186,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -212,9 +212,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -254,9 +254,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -280,9 +280,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -331,9 +331,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -352,9 +352,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -398,9 +398,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -426,9 +426,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -441,7 +441,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -453,9 +453,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -473,9 +473,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -509,9 +509,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -539,9 +539,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -585,9 +585,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2022-12-31",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -610,9 +610,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2020-12-31",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -740,9 +740,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/app",
+									"raw": "{{server_url}}/v3/pay/transactions/app",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -774,7 +774,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"prepay_id\": \"wx071900406588238ff38ea3608d8b360904\"\n}"
 								}
@@ -786,9 +786,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -812,9 +812,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -854,9 +854,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -880,9 +880,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -931,9 +931,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -968,10 +968,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -990,9 +990,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1033,7 +1033,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -1045,9 +1045,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1065,9 +1065,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1099,9 +1099,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1175,9 +1175,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2022-12-31",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1200,9 +1200,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+											"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2022-12-31",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1330,9 +1330,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/h5",
+									"raw": "{{server_url}}/v3/pay/transactions/h5",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1349,9 +1349,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/h5",
+											"raw": "{{server_url}}/v3/pay/transactions/h5",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1364,7 +1364,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n\t\"h5_url\": \"https://wx.tenpay.com/cgi-bin/mmpayweb-bin/checkmweb?prepay_id=wx2916263004719461949c84457c735b0000&package=2150917749\"\n    ///支付跳转链接:  h5_url为拉起微信支付收银台的中间页面，可通过访问该url来拉起微信客户端，完成支付，h5_url的有效期为5分钟。\n}"
 								}
@@ -1376,9 +1376,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1402,9 +1402,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1444,9 +1444,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1470,9 +1470,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1521,9 +1521,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1542,9 +1542,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1588,9 +1588,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1616,9 +1616,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1631,7 +1631,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -1643,9 +1643,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1663,9 +1663,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1699,9 +1699,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1729,9 +1729,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1775,9 +1775,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2022-12-31",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1800,9 +1800,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2020-12-31",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1930,9 +1930,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/native",
+									"raw": "{{server_url}}/v3/pay/transactions/native",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1949,9 +1949,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/native",
+											"raw": "{{server_url}}/v3/pay/transactions/native",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1964,7 +1964,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n\t\"code_url\": \"weixin://wxpay/bizpayurl?pr=p4lpSuKzz\"\n    ///此URL用于生成支付二维码，然后提供给用户扫码支付。\n    ///注意：code_url并非固定值，使用时按照URL格式转成二维码即可。\n}"
 								}
@@ -1976,9 +1976,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2002,9 +2002,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2044,9 +2044,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2070,9 +2070,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2121,9 +2121,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2142,9 +2142,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2188,9 +2188,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2216,9 +2216,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2231,7 +2231,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -2243,9 +2243,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2263,9 +2263,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2299,9 +2299,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2329,9 +2329,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2375,9 +2375,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2022-12-31",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2400,9 +2400,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2020-12-31",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2530,9 +2530,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+									"raw": "{{server_url}}/v3/pay/transactions/jsapi",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2549,9 +2549,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/jsapi",
+											"raw": "{{server_url}}/v3/pay/transactions/jsapi",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2562,7 +2562,7 @@
 										}
 									},
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"prepay_id\": \"wx042120326484513d5ff2fe243d766e0000\"\n    /* 预支付交易会话标识。用于后续接口调用中使用，该值有效期为2小时 */\n}"
 								}
@@ -2574,9 +2574,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2600,9 +2600,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{将此处替换为要查询的商户订单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2642,9 +2642,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2668,9 +2668,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/pay/transactions/id/{{将此处替换为要查询的微信支付单号}}?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2719,9 +2719,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+									"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2740,9 +2740,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的商家订单号}}/close",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2786,9 +2786,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2814,9 +2814,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2829,7 +2829,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": [],
+									"header": null,
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -2841,9 +2841,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2861,9 +2861,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的商户自己生成的退款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2897,9 +2897,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
+									"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2022-12-31&bill_type=ALL",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2927,9 +2927,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2973,9 +2973,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2022-12-31",
+									"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2022-12-31",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2998,9 +2998,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/bill/fundflowbill?bill_date=2020-12-31",
+											"raw": "{{server_url}}/v3/bill/fundflowbill?bill_date=2020-12-31",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3133,9 +3133,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/smartguide/guides",
+									"raw": "{{server_url}}/v3/smartguide/guides",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3160,9 +3160,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/smartguide/guides",
+											"raw": "{{server_url}}/v3/smartguide/guides",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3203,9 +3203,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/smartguide/guides/{{请把此处替换服务人员ID}}/assign",
+									"raw": "{{server_url}}/v3/smartguide/guides/{{请把此处替换服务人员ID}}/assign",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3232,9 +3232,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/smartguide/guides/{{请在此处替换服务人员ID}}/assign",
+											"raw": "{{server_url}}/v3/smartguide/guides/{{请在此处替换服务人员ID}}/assign",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3247,10 +3247,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -3260,9 +3260,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/smartguide/guides?store_id=1234",
+									"raw": "{{server_url}}/v3/smartguide/guides?store_id=1234",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3285,9 +3285,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/smartguide/guides?store_id=1234",
+											"raw": "{{server_url}}/v3/smartguide/guides?store_id=1234",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3335,9 +3335,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/smartguide/guides/{{请将此处替换为服务人员ID}}",
+									"raw": "{{server_url}}/v3/smartguide/guides/{{请将此处替换为服务人员ID}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3374,9 +3374,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/businesscircle/points/notify",
+									"raw": "{{server_url}}/v3/businesscircle/points/notify",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3402,9 +3402,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/businesscircle/points/notify",
+											"raw": "{{server_url}}/v3/businesscircle/points/notify",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3416,10 +3416,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -3429,9 +3429,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/businesscircle/user-authorizations/{{此处替换为要查询的openid}}?appid={{appid}}",
+									"raw": "{{server_url}}/v3/businesscircle/user-authorizations/{{此处替换为要查询的openid}}?appid={{appid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3455,9 +3455,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/businesscircle/user-authorizations/{{此处替换为要查询的openid}}?appid={{appid}}",
+											"raw": "{{server_url}}/v3/businesscircle/user-authorizations/{{此处替换为要查询的openid}}?appid={{appid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3495,9 +3495,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/businesscircle/users/{{此处替换为要查询的openid}}/points/commit_status?brandid=1000&appid={{appid}}",
+									"raw": "{{server_url}}/v3/businesscircle/users/{{此处替换为要查询的openid}}/points/commit_status?brandid=1000&appid={{appid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3528,9 +3528,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/businesscircle/users/{{此处替换为要查询的openid}}/points/commit_status?brandid=1000&appid={{appid}}",
+											"raw": "{{server_url}}/v3/businesscircle/users/{{此处替换为要查询的openid}}/points/commit_status?brandid=1000&appid={{appid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3586,9 +3586,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/businesscircle/parkings",
+									"raw": "{{server_url}}/v3/businesscircle/parkings",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3613,9 +3613,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/businesscircle/parkings",
+											"raw": "{{server_url}}/v3/businesscircle/parkings",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3626,10 +3626,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						}
@@ -3644,9 +3644,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/vehicle/parking/services/find?appid={{appid}}&plate_number=%E7%B2%A4B888888&plate_color=BLUE&openid={{openid}}",
+									"raw": "{{server_url}}/v3/vehicle/parking/services/find?appid={{appid}}&plate_number=%E7%B2%A4B888888&plate_color=BLUE&openid={{openid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3686,9 +3686,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/vehicle/parking/services/find?appid={{appid}}&plate_number=%E7%B2%A4B888888&plate_color=BLUE&openid={{openid}}",
+											"raw": "{{server_url}}/v3/vehicle/parking/services/find?appid={{appid}}&plate_number=%E7%B2%A4B888888&plate_color=BLUE&openid={{openid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3751,9 +3751,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/vehicle/parking/parkings",
+									"raw": "{{server_url}}/v3/vehicle/parking/parkings",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3779,9 +3779,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/vehicle/parking/parkings",
+											"raw": "{{server_url}}/v3/vehicle/parking/parkings",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3823,9 +3823,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/vehicle/transactions/parking",
+									"raw": "{{server_url}}/v3/vehicle/transactions/parking",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3851,9 +3851,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/vehicle/transactions/parking",
+											"raw": "{{server_url}}/v3/vehicle/transactions/parking",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3886,9 +3886,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/vehicle/transactions/out-trade-no/{{此处替换为你要查询的订单号}}",
+									"raw": "{{server_url}}/v3/vehicle/transactions/out-trade-no/{{此处替换为你要查询的订单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3906,9 +3906,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/vehicle/transactions/out-trade-no/20150806125346",
+											"raw": "{{server_url}}/v3/vehicle/transactions/out-trade-no/20150806125346",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3951,9 +3951,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3979,9 +3979,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4014,9 +4014,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的退款单号}}",
+									"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的退款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4034,9 +4034,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/refund/domestic/refunds/{{此处替换为要查询的退款单号}}",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds/{{此处替换为要查询的退款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4087,9 +4087,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/coupon-stocks",
+									"raw": "{{server_url}}/v3/marketing/favor/coupon-stocks",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4115,9 +4115,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/coupon-stocks",
+											"raw": "{{server_url}}/v3/marketing/favor/coupon-stocks",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4159,9 +4159,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要激活的代金券批次ID}}/start",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/{{此处替换为要激活的代金券批次ID}}/start",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4189,9 +4189,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要激活的代金券批次ID}}/start",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/{{此处替换为要激活的代金券批次ID}}/start",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4235,9 +4235,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/users/{{此处替换为你要发放的openid}}/coupons",
+									"raw": "{{server_url}}/v3/marketing/favor/users/{{此处替换为你要发放的openid}}/coupons",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4265,9 +4265,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/users/{{此处替换为你要发放的openid}}/coupons",
+											"raw": "{{server_url}}/v3/marketing/favor/users/{{此处替换为你要发放的openid}}/coupons",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4311,9 +4311,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要暂停的代金券批次id}}/pause",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/{{替换为你要暂停的代金券批次id}}/pause",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4341,9 +4341,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要暂停的代金券批次id}}/pause",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/{{替换为你要暂停的代金券批次id}}/pause",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4385,9 +4385,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要重启的代金券批次id}}/restart",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/{{替换为你要重启的代金券批次id}}/restart",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4415,9 +4415,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{替换为你要重启的代金券批次id}}/restart",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/{{替换为你要重启的代金券批次id}}/restart",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4450,9 +4450,9 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4501,9 +4501,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks?offset=0&limit=10&stock_creator_mchid=9856888&create_start_time=2015-05-20T13%3A29%3A35%2B08%3A00&create_end_time=2015-05-20T19%3A29%3A35%2B08%3A00&status=running",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4568,9 +4568,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要查询的代金券批次ID}}?stock_creator_mchid=123456",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/{{此处替换为要查询的代金券批次ID}}?stock_creator_mchid=123456",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4595,9 +4595,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{{此处替换为要查询的代金券批次ID}}?stock_creator_mchid=123456",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/{{此处替换为要查询的代金券批次ID}}?stock_creator_mchid=123456",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4636,9 +4636,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/users/{{openid}}/coupons/{{此处替换为要查询的代金券id}}?appid=wx233544546545989",
+									"raw": "{{server_url}}/v3/marketing/favor/users/{{openid}}/coupons/{{此处替换为要查询的代金券id}}?appid=wx233544546545989",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4665,9 +4665,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/users/{{openid}}/coupons/{{此处替换为要查询的代金券id}}?appid={{appid}}",
+											"raw": "{{server_url}}/v3/marketing/favor/users/{{openid}}/coupons/{{此处替换为要查询的代金券id}}?appid={{appid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4710,9 +4710,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/merchants?offset=0&limit=10&stock_creator_mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/9865000/merchants?offset=0&limit=10&stock_creator_mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4748,9 +4748,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/merchants?offset=0&limit=10&stock_creator_mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/9865000/merchants?offset=0&limit=10&stock_creator_mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4802,9 +4802,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/items?offset=10&limit=10&stock_creator_mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/9865000/items?offset=10&limit=10&stock_creator_mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4840,9 +4840,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/9865000/items?offset=10&limit=10&stock_creator_mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/9865000/items?offset=10&limit=10&stock_creator_mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -4894,9 +4894,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/users/{{此处替换为要查询的用户的openid}}/coupons?appid={{appid}}",
+									"raw": "{{server_url}}/v3/marketing/favor/users/{{此处替换为要查询的用户的openid}}/coupons?appid={{appid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -4958,9 +4958,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/users/2323dfsdf342342/coupons?appid={{appid}}",
+											"raw": "{{server_url}}/v3/marketing/favor/users/2323dfsdf342342/coupons?appid={{appid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5038,9 +5038,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/use-flow",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/{stock_id}/use-flow",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5059,9 +5059,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/use-flow",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/{stock_id}/use-flow",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5096,9 +5096,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/refund-flow",
+									"raw": "{{server_url}}/v3/marketing/favor/stocks/{stock_id}/refund-flow",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5117,9 +5117,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/stocks/{stock_id}/refund-flow",
+											"raw": "{{server_url}}/v3/marketing/favor/stocks/{stock_id}/refund-flow",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5163,9 +5163,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/favor/callbacks",
+									"raw": "{{server_url}}/v3/marketing/favor/callbacks",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5191,9 +5191,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/favor/callbacks",
+											"raw": "{{server_url}}/v3/marketing/favor/callbacks",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5240,9 +5240,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks",
+									"raw": "{{server_url}}/v3/marketing/busifavor/stocks",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5260,9 +5260,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要查询的商家去批次ID}}",
+									"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{{此处替换为要查询的商家去批次ID}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5280,9 +5280,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要查询的商家去批次ID}}",
+											"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{{此处替换为要查询的商家去批次ID}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5325,9 +5325,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/use",
+									"raw": "{{server_url}}/v3/marketing/busifavor/coupons/use",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5354,9 +5354,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/use",
+											"raw": "{{server_url}}/v3/marketing/busifavor/coupons/use",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5390,9 +5390,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons?appid=wx233544546545989&stock_id=9865000&coupon_state=USED&creator_merchant=1000000001&offset=0&limit=20",
+									"raw": "{{server_url}}/v3/marketing/busifavor/users/{{openid}}/coupons?appid=wx233544546545989&stock_id=9865000&coupon_state=USED&creator_merchant=1000000001&offset=0&limit=20",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5443,9 +5443,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons?appid=wx233544546545989&stock_id=9865000&coupon_state=USED&creator_merchant=1000000001&offset=0&limit=20",
+											"raw": "{{server_url}}/v3/marketing/busifavor/users/{{openid}}/coupons?appid=wx233544546545989&stock_id=9865000&coupon_state=USED&creator_merchant=1000000001&offset=0&limit=20",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5510,9 +5510,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons/{{此处替换为要查询的商家券code}}/appids/{{appid}}",
+									"raw": "{{server_url}}/v3/marketing/busifavor/users/{{openid}}/coupons/{{此处替换为要查询的商家券code}}/appids/{{appid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5534,9 +5534,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/users/{{openid}}/coupons/{{此处替换为要查询的商家券code}}/appids/{{appid}}",
+											"raw": "{{server_url}}/v3/marketing/busifavor/users/{{openid}}/coupons/{{此处替换为要查询的商家券code}}/appids/{{appid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5581,9 +5581,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}/couponcodes",
+									"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{stock_id}/couponcodes",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5611,9 +5611,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}/couponcodes",
+											"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{stock_id}/couponcodes",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5657,9 +5657,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks",
+									"raw": "{{server_url}}/v3/marketing/busifavor/callbacks",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5685,9 +5685,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks",
+											"raw": "{{server_url}}/v3/marketing/busifavor/callbacks",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5720,9 +5720,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks?mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/marketing/busifavor/callbacks?mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5746,9 +5746,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/callbacks?mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/marketing/busifavor/callbacks?mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5795,9 +5795,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/associate",
+									"raw": "{{server_url}}/v3/marketing/busifavor/coupons/associate",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5824,9 +5824,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/associate",
+											"raw": "{{server_url}}/v3/marketing/busifavor/coupons/associate",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5869,9 +5869,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/disassociate",
+									"raw": "{{server_url}}/v3/marketing/busifavor/coupons/disassociate",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5898,9 +5898,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/disassociate",
+											"raw": "{{server_url}}/v3/marketing/busifavor/coupons/disassociate",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -5943,9 +5943,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要修改预算的商家券批次号}}/budget",
+									"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{{此处替换为要修改预算的商家券批次号}}/budget",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -5973,9 +5973,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{{此处替换为要修改预算的商家券批次号}}/budget",
+											"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{{此处替换为要修改预算的商家券批次号}}/budget",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6019,9 +6019,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}",
+									"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{stock_id}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6048,9 +6048,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/stocks/{stock_id}",
+											"raw": "{{server_url}}/v3/marketing/busifavor/stocks/{stock_id}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6063,10 +6063,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -6085,9 +6085,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/return",
+									"raw": "{{server_url}}/v3/marketing/busifavor/coupons/return",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6114,9 +6114,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/return",
+											"raw": "{{server_url}}/v3/marketing/busifavor/coupons/return",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6159,9 +6159,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/deactivate",
+									"raw": "{{server_url}}/v3/marketing/busifavor/coupons/deactivate",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6188,9 +6188,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/coupons/deactivate",
+											"raw": "{{server_url}}/v3/marketing/busifavor/coupons/deactivate",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6233,9 +6233,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts",
+									"raw": "{{server_url}}/v3/marketing/busifavor/subsidy/pay-receipts",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6262,9 +6262,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts",
+											"raw": "{{server_url}}/v3/marketing/busifavor/subsidy/pay-receipts",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6298,9 +6298,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts/{{此处替换为要查询的补差付款单号}}",
+									"raw": "{{server_url}}/v3/marketing/busifavor/subsidy/pay-receipts/{{此处替换为要查询的补差付款单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6319,9 +6319,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/busifavor/subsidy/pay-receipts/{{此处替换为要查询的补差付款单号}}",
+											"raw": "{{server_url}}/v3/marketing/busifavor/subsidy/pay-receipts/{{此处替换为要查询的补差付款单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6377,9 +6377,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/partnerships/build",
+									"raw": "{{server_url}}/v3/marketing/partnerships/build",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6412,9 +6412,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/partnerships/build",
+											"raw": "{{server_url}}/v3/marketing/partnerships/build",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6447,9 +6447,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/partnerships?authorized_data=%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d&partner=%7b%22type%22%3a%22APPID%22%7d&offset=0&limit=5",
+									"raw": "{{server_url}}/v3/marketing/partnerships?authorized_data=%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d&partner=%7b%22type%22%3a%22APPID%22%7d&offset=0&limit=5",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6487,9 +6487,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/marketing/partnerships?authorized_data=%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d&partner=%7b%22type%22%3a%22APPID%22%7d&offset=0&limit=5",
+											"raw": "{{server_url}}/v3/marketing/partnerships?authorized_data=%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d&partner=%7b%22type%22%3a%22APPID%22%7d&offset=0&limit=5",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6553,9 +6553,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/unique-threshold-activity",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/unique-threshold-activity",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6573,9 +6573,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6594,9 +6594,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001/merchants?offset=1&limit=20",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001/merchants?offset=1&limit=20",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6626,9 +6626,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001/goods?offset=1&limit=20",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001/goods?offset=1&limit=20",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6658,9 +6658,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/10028001/terminate",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001/terminate",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6689,9 +6689,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/add",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/add",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6712,9 +6712,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities?offset=0&limit=10&activity_status=ONGOING_ACT_STATUS",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities?offset=0&limit=10&activity_status=ONGOING_ACT_STATUS",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6755,9 +6755,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/delete",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/delete",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6797,9 +6797,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/batches",
+									"raw": "{{server_url}}/v3/transfer/batches",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6824,9 +6824,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/batches",
+											"raw": "{{server_url}}/v3/transfer/batches",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6858,9 +6858,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+									"raw": "{{server_url}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6900,9 +6900,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+											"raw": "{{server_url}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -6958,9 +6958,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}/details/detail-id/{{此处要替换为要查询的微信明细单号}}",
+									"raw": "{{server_url}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}/details/detail-id/{{此处要替换为要查询的微信明细单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -6981,9 +6981,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}/details/detail-id/{{此处要替换为要查询的微信明细单号}}",
+											"raw": "{{server_url}}/v3/transfer/batches/batch-id/{{此处替换为要查询的微信批次单号}}/details/detail-id/{{此处要替换为要查询的微信明细单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7020,9 +7020,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+									"raw": "{{server_url}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7062,9 +7062,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
+											"raw": "{{server_url}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的微信批次单号}}?need_query_detail=true&detail_status=ALL&offset=0&limit=20",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7120,9 +7120,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的商家批次单号}}/details/out-detail-no/{{此处要替换为要查询的商家明细单号}}",
+									"raw": "{{server_url}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的商家批次单号}}/details/out-detail-no/{{此处要替换为要查询的商家明细单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7143,9 +7143,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的商家批次单号}}/details/out-detail-no/{{此处要替换为要查询的商家明细单号}}",
+											"raw": "{{server_url}}/v3/transfer/batches/out-batch-no/{{此处替换为要查询的商家批次单号}}/details/out-detail-no/{{此处要替换为要查询的商家明细单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7190,9 +7190,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/bill-receipt",
+									"raw": "{{server_url}}/v3/transfer/bill-receipt",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7217,9 +7217,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/bill-receipt",
+											"raw": "{{server_url}}/v3/transfer/bill-receipt",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7251,9 +7251,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer/bill-receipt/{{此处替换为要查询的商家批次单号}}",
+									"raw": "{{server_url}}/v3/transfer/bill-receipt/{{此处替换为要查询的商家批次单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7270,9 +7270,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer/bill-receipt/{out_batch_no}",
+											"raw": "{{server_url}}/v3/transfer/bill-receipt/{out_batch_no}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7314,9 +7314,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts",
+									"raw": "{{server_url}}/v3/transfer-detail/electronic-receipts",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7341,9 +7341,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts",
+											"raw": "{{server_url}}/v3/transfer-detail/electronic-receipts",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7375,9 +7375,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts?accept_type=BATCH_TRANSFER&out_batch_no=pay2022022222220222&out_detail_no=MX2022022200001",
+									"raw": "{{server_url}}/v3/transfer-detail/electronic-receipts?accept_type=BATCH_TRANSFER&out_batch_no=pay2022022222220222&out_detail_no=MX2022022200001",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7410,9 +7410,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/transfer-detail/electronic-receipts?accept_type=BATCH_TRANSFER&out_batch_no=pay2022022222220222&out_detail_no=MX2022022200001",
+											"raw": "{{server_url}}/v3/transfer-detail/electronic-receipts?accept_type=BATCH_TRANSFER&out_batch_no=pay2022022222220222&out_detail_no=MX2022022200001",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7506,9 +7506,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/orders",
+									"raw": "{{server_url}}/v3/profitsharing/orders",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7533,9 +7533,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/orders",
+											"raw": "{{server_url}}/v3/profitsharing/orders",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7567,9 +7567,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
+									"raw": "{{server_url}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7580,7 +7580,7 @@
 									"query": [
 										{
 											"key": null,
-											"value": ""
+											"value": null
 										},
 										{
 											"key": "transaction_id",
@@ -7597,9 +7597,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
+											"raw": "{{server_url}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7652,9 +7652,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/return-orders",
+									"raw": "{{server_url}}/v3/profitsharing/return-orders",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7679,9 +7679,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/return-orders",
+											"raw": "{{server_url}}/v3/profitsharing/return-orders",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7713,9 +7713,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/return-orders/{{此处替换为要查询的商家分账回退单号}}?&out_order_no=P2022111111111100011",
+									"raw": "{{server_url}}/v3/profitsharing/return-orders/{{此处替换为要查询的商家分账回退单号}}?&out_order_no=P2022111111111100011",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7726,7 +7726,7 @@
 									"query": [
 										{
 											"key": null,
-											"value": ""
+											"value": null
 										},
 										{
 											"key": "out_order_no",
@@ -7743,9 +7743,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/return-orders/{{此处替换为要查询的商家分账回退单号}}?&out_order_no=P2022111111111100011",
+											"raw": "{{server_url}}/v3/profitsharing/return-orders/{{此处替换为要查询的商家分账回退单号}}?&out_order_no=P2022111111111100011",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7798,9 +7798,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/orders/unfreeze",
+									"raw": "{{server_url}}/v3/profitsharing/orders/unfreeze",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7826,9 +7826,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/orders/unfreeze",
+											"raw": "{{server_url}}/v3/profitsharing/orders/unfreeze",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7859,9 +7859,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/transactions/{{请将此处替换为要查询剩余待分金额的微信支付订单号}}/amounts",
+									"raw": "{{server_url}}/v3/profitsharing/transactions/{{请将此处替换为要查询剩余待分金额的微信支付订单号}}/amounts",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7879,9 +7879,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/transactions/{{请将此处替换为要查询剩余待分金额的微信支付订单号}}/amounts",
+											"raw": "{{server_url}}/v3/profitsharing/transactions/{{请将此处替换为要查询剩余待分金额的微信支付订单号}}/amounts",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7927,9 +7927,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/receivers/add",
+									"raw": "{{server_url}}/v3/profitsharing/receivers/add",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7945,10 +7945,19 @@
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_8.shtml\n   接口说明：商户发起添加分账接收方请求，建立分账接收方列表。后续可通过发起分账请求，将分账方商户结算后的资金，分到该分账接收方\n   注意：商户需确保向微信支付传输用户身份信息和账号标识信息做一致性校验已合法征得用户授权 */\n{\n  \"appid\": \"wx8888888888888888\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n  \"relation_type\": \"CUSTOM\",\n  /*商户与接收方的关系。 本字段值为枚举：STORE：门店 STAFF：员工 STORE_OWNER：店主 PARTNER：合作伙伴 HEADQUARTER：总部 BRAND：品牌方 DISTRIBUTOR：分销商\n    USER：用户 SUPPLIER： 供应商 CUSTOM：自定义 */\n  \"custom_relation\": \"代理商\"///商户与接收方具体的关系，本字段最多10个字。当字段relation_type的值为CUSTOM时，本字段必填;当字段relation_type的值不为CUSTOM时，本字段无需填写。\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/receivers/add",
+											"raw": "{{server_url}}/v3/profitsharing/receivers/add",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -7993,9 +8002,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/receivers/delete",
+									"raw": "{{server_url}}/v3/profitsharing/receivers/delete",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8011,10 +8020,19 @@
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_9.shtml\n   接口说明：商户发起删除分账接收方请求。删除后，不支持将分账方商户结算后的资金，分到该分账接收方 */\n{\n  \"appid\": \"{{appid}}\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"1900000109\"///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/receivers/delete",
+											"raw": "{{server_url}}/v3/profitsharing/receivers/delete",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8047,9 +8065,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/profitsharing/bills?bill_date=2022-11-11",
+									"raw": "{{server_url}}/v3/profitsharing/bills?bill_date=2022-11-11",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8072,9 +8090,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/profitsharing/bills?bill_date=2022-11-11",
+											"raw": "{{server_url}}/v3/profitsharing/bills?bill_date=2022-11-11",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8121,9 +8139,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2?limit=5&offset=10&begin_date=2022-11-01&end_date=2022-11-11&complainted_mchid={{mchid}}",
+									"raw": "{{server_url}}/v3/merchant-service/complaints-v2?limit=5&offset=10&begin_date=2022-11-01&end_date=2022-11-11&complainted_mchid={{mchid}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8166,9 +8184,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2?limit=5&offset=10&begin_date=2022-11-01&end_date=2022-11-11&complainted_mchid={{mchid}}",
+											"raw": "{{server_url}}/v3/merchant-service/complaints-v2?limit=5&offset=10&begin_date=2022-11-01&end_date=2022-11-11&complainted_mchid={{mchid}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8227,9 +8245,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}",
+									"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8246,9 +8264,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}",
+											"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8281,9 +8299,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}/negotiation-historys?limit=50&offset=0",
+									"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}/negotiation-historys?limit=50&offset=0",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8313,9 +8331,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}/negotiation-historys?limit=50&offset=0",
+											"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{请将此处替换为要查询的投诉单对应的投诉单号}}/negotiation-historys?limit=50&offset=0",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8370,9 +8388,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8397,9 +8415,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8431,9 +8449,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8449,9 +8467,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8492,9 +8510,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8519,9 +8537,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8553,9 +8571,9 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+									"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8571,9 +8589,9 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaint-notifications",
+											"raw": "{{server_url}}/v3/merchant-service/complaint-notifications",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8584,10 +8602,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -8606,9 +8624,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要回复的投诉单对应的投诉单号}}/response",
+									"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{请将此处替换为要回复的投诉单对应的投诉单号}}/response",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8635,9 +8653,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{请将此处替换为要回复的投诉单对应的投诉单号}}/response",
+											"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{请将此处替换为要回复的投诉单对应的投诉单号}}/response",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8650,10 +8668,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -8672,9 +8690,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为反馈处理完成的投诉单号}}/complete",
+									"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{此处替换为反馈处理完成的投诉单号}}/complete",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8701,9 +8719,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为反馈处理完成的投诉单号}}/complete",
+											"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{此处替换为反馈处理完成的投诉单号}}/complete",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8716,10 +8734,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						},
@@ -8738,9 +8756,9 @@
 									}
 								},
 								"url": {
-									"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为投诉单对应的投诉单号}}/update-refund-progress",
+									"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{此处替换为投诉单对应的投诉单号}}/update-refund-progress",
 									"host": [
-										"{{endpoint}}"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -8767,9 +8785,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{endpoint}}/v3/merchant-service/complaints-v2/{{此处替换为投诉单对应的投诉单号}}/update-refund-progress",
+											"raw": "{{server_url}}/v3/merchant-service/complaints-v2/{{此处替换为投诉单对应的投诉单号}}/update-refund-progress",
 											"host": [
-												"{{endpoint}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -8782,10 +8800,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": "Text",
-									"header": [],
+									"_postman_previewlanguage": null,
+									"header": null,
 									"cookie": [],
-									"body": ""
+									"body": null
 								}
 							]
 						}

--- a/wechatpay-apiv3.postman_collection.json
+++ b/wechatpay-apiv3.postman_collection.json
@@ -1,7 +1,8 @@
 {
 	"info": {
-		"_postman_id": "efe705f2-fba8-4d3a-b11b-eea043018023",
+		"_postman_id": "b0b733ba-a440-41d4-a5ac-ad7620500fd0",
 		"name": "微信支付 APIv3",
+		"description": "[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/15520576-b0b733ba-a440-41d4-a5ac-ad7620500fd0?action=collection%2Ffork&collection-url=entityId%3D15520576-b0b733ba-a440-41d4-a5ac-ad7620500fd0%26entityType%3Dcollection%26workspaceId%3Da4c4f830-deea-405a-924f-d3b20cdf5eb2)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "15520576"
 	},
@@ -174,7 +175,7 @@
 										}
 									},
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"prepay_id\": \"wx042120326484513d5ff2fe243d766e0000\"\n    /* 预支付交易会话标识。用于后续接口调用中使用，该值有效期为2小时 */\n}"
 								}
@@ -441,7 +442,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -651,14 +652,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-									"protocol": "https",
+									"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -681,14 +677,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-											"protocol": "https",
+											"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 											"host": [
-												"api",
-												"mch",
-												"weixin",
-												"qq",
-												"com"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -759,9 +750,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{domain}}/v3/pay/transactions/app",
+											"raw": "{{server_url}}/v3/pay/transactions/app",
 											"host": [
-												"{{domain}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -774,7 +765,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"prepay_id\": \"wx071900406588238ff38ea3608d8b360904\"\n}"
 								}
@@ -952,9 +943,9 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{domain}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的订单号}}/close",
+											"raw": "{{server_url}}/v3/pay/transactions/out-trade-no/{{此处替换为要关闭的订单号}}/close",
 											"host": [
-												"{{domain}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -968,10 +959,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -1018,9 +1009,9 @@
 											}
 										},
 										"url": {
-											"raw": "{{domain}}/v3/refund/domestic/refunds",
+											"raw": "{{server_url}}/v3/refund/domestic/refunds",
 											"host": [
-												"{{domain}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1033,7 +1024,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -1129,9 +1120,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{domain}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
+											"raw": "{{server_url}}/v3/bill/tradebill?bill_date=2020-12-31&bill_type=ALL",
 											"host": [
-												"{{domain}}"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1241,14 +1232,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-									"protocol": "https",
+									"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1271,14 +1257,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-											"protocol": "https",
+											"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 											"host": [
-												"api",
-												"mch",
-												"weixin",
-												"qq",
-												"com"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -1364,7 +1345,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n\t\"h5_url\": \"https://wx.tenpay.com/cgi-bin/mmpayweb-bin/checkmweb?prepay_id=wx2916263004719461949c84457c735b0000&package=2150917749\"\n    ///支付跳转链接:  h5_url为拉起微信支付收银台的中间页面，可通过访问该url来拉起微信客户端，完成支付，h5_url的有效期为5分钟。\n}"
 								}
@@ -1631,7 +1612,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -1841,14 +1822,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-									"protocol": "https",
+									"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -1858,8 +1834,7 @@
 									"query": [
 										{
 											"key": "token",
-											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-											"description": "通过申请账单接口获取到“download_url”，URL有效期30s"
+											"value": "6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO"
 										}
 									]
 								}
@@ -1964,7 +1939,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n\t\"code_url\": \"weixin://wxpay/bizpayurl?pr=p4lpSuKzz\"\n    ///此URL用于生成支付二维码，然后提供给用户扫码支付。\n    ///注意：code_url并非固定值，使用时按照URL格式转成二维码即可。\n}"
 								}
@@ -2231,7 +2206,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -2441,14 +2416,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-									"protocol": "https",
+									"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -2471,14 +2441,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-											"protocol": "https",
+											"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 											"host": [
-												"api",
-												"mch",
-												"weixin",
-												"qq",
-												"com"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -2562,7 +2527,7 @@
 										}
 									},
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"prepay_id\": \"wx042120326484513d5ff2fe243d766e0000\"\n    /* 预支付交易会话标识。用于后续接口调用中使用，该值有效期为2小时 */\n}"
 								}
@@ -2829,7 +2794,7 @@
 									"status": "OK",
 									"code": 200,
 									"_postman_previewlanguage": "json",
-									"header": null,
+									"header": [],
 									"cookie": [],
 									"body": "{\n    \"refund_id\": \"50000000382019052709732678859\", ///微信支付退款单号\n    \"out_refund_no\": \"1217752501201407033233368018\",///商户自定义的退款单号\t，在商户号下需要保持唯一\n    \"transaction_id\": \"4200000891202103228088184743\",///原支付交易对应的微信支付交易订单号\n    \"out_trade_no\": \"1217752501201407033233368018\",///原支付交易对应的商户订单号\n    \"channel\": \"ORIGINAL\",///退款渠道 枚举值：ORIGINAL：原路退款；BALANCE：退回到余额；OTHER_BALANCE：原账户异常退到其他余额账户；OTHER_BANKCARD：原银行卡异常退到其他银行卡\n    \"user_received_account\": \"招商银行信用卡0403\", ///退款入账账户，取当前退款单的退款入账方，有以下几种情况：1）退回银行卡：{银行名称}{卡类型}{卡尾号}；2）退回支付用户零钱:支付用户零钱；3）退还商户:商户基本账户商户结算银行账户；4）退回支付用户零钱通:支付用户零钱通\n    \"success_time\": \"2020-12-01T16:18:12+08:00\",///退款成功时间，当退款状态为退款成功时有返回。\n    \"create_time\": \"2020-12-01T16:18:12+08:00\",///退款受理时间\n    \"status\": \"SUCCESS\", ///退款单状态，退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台-交易中心，手动处理此笔退款。枚举值：SUCCESS：退款成功；CLOSED：退款关闭；PROCESSING：退款处理中；ABNORMAL：退款异常\n    \"funds_account\": \"UNSETTLED\", ///退款所使用资金对应的资金账户类型枚举值：UNSETTLED : 未结算资金；AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额；OPERATION : 运营户；BASIC : 基本账户（含可用余额和不可用余额）\n    \"amount\": {\n        \"total\": 100,///订单总金额，单位为分\n        \"refund\": 100,///退款标价金额，单位为分，可以做部分退款\n        \"from\": [\n            {\n                \"account\": \"AVAILABLE\", ///退款出资账户类型：枚举值：AVAILABLE : 可用余额；UNAVAILABLE : 不可用余额\n                \"amount\": 444 ///对应账户出资金额\n            }\n        ],\n        \"payer_total\": 90,///用户实际支付金额，单位为分，只能为整数\n        \"payer_refund\": 90, ///退款给用户的金额，不包含所有优惠券金额\n        \"settlement_refund\": 100, ///去掉非充值代金券退款金额后的退款金额，单位为分，退款金额=申请退款金额-非充值代金券退款金额，退款金额<=申请退款金额\n        \"settlement_total\": 100, ///应结订单金额=订单金额-免充值代金券金额，应结订单金额<=订单金额，单位为分\n        \"discount_refund\": 10,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为现金，说明详见代金券或立减优惠，单位为分\n        \"currency\": \"CNY\" ///符合ISO 4217标准的三位字母代码，目前只支持人民币：CNY。\n    },\n    \"promotion_detail\": [\n        {\n            \"promotion_id\": \"109519\",///券或者立减优惠id\n            \"scope\": \"SINGLE\",///优惠范围 枚举值：GLOBAL：全场代金券；SINGLE：单品优惠\n            \"type\": \"DISCOUNT\",///优惠类型 枚举值：COUPON：代金券，需要走结算资金的充值型代金券，俗称预充值XXX；DISCOUNT：优惠券，不走结算资金的免充值型优惠券，俗称免充值XXX\n            \"amount\": 5,///用户享受优惠的金额（优惠券面额=微信出资金额+商家出资金额+其他出资方金额 ），单位为分\n            \"refund_amount\": 100,///优惠退款金额<=退款金额，退款金额-代金券或立减优惠退款金额为用户支付的现金，说明详见代金券或立减优惠，单位为分\n            \"goods_detail\": [\n                {\n                    \"merchant_goods_id\": \"1217752501201407033233368018\", ///商户侧定义的商品编码\n                    \"wechatpay_goods_id\": \"1001\",///微信支付定义的统一商品编号（没有可不传）\n                    \"goods_name\": \"iPhone20s 16T\", ///单品商品的实际名称\n                    \"unit_price\": 8528800,///商品单价金额，单位为分\n                    \"refund_amount\": 8528800,///商品退款金额，单位为分\n                    \"refund_quantity\": 1 ///单品的退款数量\n                }\n            ]\n        }\n    ]\n}"
 								}
@@ -3039,14 +3004,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-									"protocol": "https",
+									"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -3069,14 +3029,9 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-											"protocol": "https",
+											"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 											"host": [
-												"api",
-												"mch",
-												"weixin",
-												"qq",
-												"com"
+												"{{server_url}}"
 											],
 											"path": [
 												"v3",
@@ -3247,10 +3202,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -3324,7 +3279,13 @@
 							"name": "服务人员信息更新",
 							"request": {
 								"method": "PATCH",
-								"header": [],
+								"header": [
+									{
+										"key": "Wechatpay-Serial",
+										"value": "",
+										"type": "text"
+									}
+								],
 								"body": {
 									"mode": "raw",
 									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_4_4.shtml\n   接口说明：用于商户开发者为商户更新门店服务人员的姓名、头像等信息 */\n{\n  \"name\": \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///需更新的服务人员姓名，不更新无需传入，该字段请使用微信支付平台公钥加密，特殊规则：加密前字段长度限制为64个字节\n  \"mobile\": \"pVd1HJ6v/69bDnuC4EL5Kz4jBHLiCa8MRtelw/wDa4SzfeespQO/0kjiwfqdfg==\",///需更新的服务人员手机号码，不更新无需传入，该字段请使用微信支付平台公钥加密，特殊规则：加密前字段长度限制为32个字节\n  \"qr_code\": \"https://open.work.weixin.qq.com/wwopen/userQRCode?vcode=xxx\", ///需更新的服务人员二维码，不更新无需传入，企业微信商家适用，个人微信商家不可用\n  \"avatar\": \"http://wx.qlogo.cn/mmopen/ajNVdqHZLLA3WJ6DSZUfiakYe37PKnQhBIeOQBO4czqrnZDS79FH5Wm5m4X69TBicnHFlhiafvDwklOpZeXYQQ2icg/0\",///需更新的服务人员头像URL，不更新无需传入\n  \"group_qrcode\" : \"http://p.qpic.cn/wwhead/nMl9ssowtibVGyrmvBiaibzDtp/0\" ///员工所在门店在企业微信配置的群活码的URL\n}",
@@ -3416,10 +3377,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -3626,10 +3587,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						}
@@ -6063,10 +6024,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -6460,12 +6421,12 @@
 										{
 											"key": "authorized_data",
 											"value": "%7b%22business_type%22%3a%22BUSIFAVOR_STOCK%22%7d",
-											"description": "被授权的数据。"
+											"description": "被授权的数据。json字符串"
 										},
 										{
 											"key": "partner",
 											"value": "%7b%22type%22%3a%22APPID%22%7d",
-											"description": "合作方相关的信息，商户自定义字段。"
+											"description": "合作方相关的信息，商户自定义字段。 json字符串"
 										},
 										{
 											"key": "offset",
@@ -6545,7 +6506,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"activity_base_info\": {\n    \"activity_name\": \"良品铺子回馈活动\",\n    \"activity_second_title\": \"海飞丝的券\",\n    \"merchant_logo_url\": \"https://tool.oschina.net/regex.jpg\",\n    \"background_color\": \"COLOR010\",\n    \"begin_time\": \"2015-05-20T13:29:35+08:00\",\n    \"end_time\": \"2015-05-20T13:29:35+08:00\",\n    \"available_periods\": {\n      \"available_time\": [\n        {\n          \"begin_time\": \"2015-05-20T00:00:00+08:00\",\n          \"end_time\": \"2015-05-20T23:59:59+08:00\"\n        }\n      ],\n      \"available_day_time\": [\n        {\n          \"begin_day_time\": \"110000\",\n          \"end_day_time\": \"135959\"\n        }\n      ]\n    },\n    \"out_request_no\": \"100002322019090134234sfdf\",\n    \"delivery_purpose\": \"OFF_LINE_PAY\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"award_send_rule\": {\n    \"transaction_amount_minimum\": 100,\n    \"send_content\": \"SINGLE_COUPON\",\n    \"award_type\": \"BUSIFAVOR\",\n    \"award_list\": [\n      {\n        \"stock_id\": \"98065001\",\n        \"original_image_url\": \"https://tool.oschina.net/regex.jpg\",\n        \"thumbnail_url\": \"https://tool.oschina.net/regex.jpg\"\n      }\n    ],\n    \"merchant_option\": \"MANUAL_INPUT_MERCHANT\",\n    \"merchant_id_list\": [\n      \"10000022\",\n      \"10000023\"\n    ]\n  },\n  \"advanced_setting\": {\n    \"delivery_user_category\": \"DELIVERY_MEMBER_PERSON\",\n    \"merchant_member_appid\": \"34567890\",\n    \"goods_tags\": [\n      \"xxx\",\n      \"yyy\"\n    ]\n  }\n}",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_2.shtml\n   接口说明：商户可以创建满额送活动，用户支付后送全场券，提升交易额。 */\n{\n  \"activity_base_info\": {\n    \"activity_name\": \"良品铺子回馈活动\", ///活动名称\n    \"activity_second_title\": \"海飞丝的券\", //活动副标题\n    \"merchant_logo_url\": \"https://tool.oschina.net/regex.jpg\", ///商户logo，送出优惠券时展示， 仅支持通过《图片上传API》接口获取的图片URL地址。\n    \"background_color\": \"COLOR010\",///代金券的背景颜色，可设置10种颜色，颜色取值请参见色卡图，默认为微信支付绿色， 颜色取值为颜色图中的颜色名称。\n    \"begin_time\": \"2015-05-20T13:29:35+08:00\",///活动开始时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"end_time\": \"2015-05-20T13:29:35+08:00\",///1、活动结束时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"out_request_no\": \"100002322019090134234sfdf\", ///商户创建批次凭据号（格式：商户id+日期+流水号），商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号。\n    \"delivery_purpose\": \"OFF_LINE_PAY\", ///投放目的：枚举值：OFF_LINE_PAY：拉用户回店消费 JUMP_MINI_APP：引导用户前往小程序消费\n    \"mini_programs_appid\": \"{{appid}}\", ///投放目的为JUMP_MINI_APP时必填\n    \"mini_programs_path\": \"/path/index/index\" ///如果传入此参数，则跳转至商家小程序；反之则跳转至券详情页面。\n  },\n  \"award_send_rule\": {\n    \"transaction_amount_minimum\": 100, ///消费金额门槛，单位：分。 注：该字段金额指订单金额\n    \"send_content\": \"SINGLE_COUPON\", ///发放内容，可选单张券或礼包，选礼包时奖品限定3-5个。枚举值：SINGLE_COUPON：单张券 GIFT_PACKAGE：礼包\n    \"award_type\": \"BUSIFAVOR\", ///奖品类型，暂时只支持商家券。枚举值： BUSIFAVOR：商家券\n    \"award_list\": [\n      {\n        \"stock_id\": \"98065001\",///券批次ID，暂时只支持商家券\n        \"original_image_url\": \"https://tool.oschina.net/regex.jpg\", ///奖品大图，图片建议尺寸：678像素*232像素，支持JPG、PNG格式； 仅支持通过《图片上传API》接口获取的图片URL地址。\n        \"thumbnail_url\": \"https://tool.oschina.net/regex.jpg\"///奖品小图，图片建议尺寸：120像素*120像素，支持JPG、PNG格式；当选多张券时必填， 仅支持通过《图片上传API》接口获取的图片URL地址。\n      }\n    ],\n    \"merchant_option\": \"MANUAL_INPUT_MERCHANT\", ///曝光商户号选取规则，支持选择在用券商户号和手动输入曝光商户号两种规则，当选择手动输入曝光商户号时，曝光商户号必填（商家券只支持手动输入）。枚举值：IN_SEVICE_COUPON_MERCHANT：在用券商户号 MANUAL_INPUT_MERCHANT：手动输入曝光商户号\n    \"merchant_id_list\": [\n      \"10000022\",\n      \"10000023\"\n      /* 曝光商户号，列表。当merchant_option为MANUAL_INPUT_MERCHANT时，该字段必填。曝光商户号需与投放的商家券归属商户号一致或有同品牌关系。\n      特殊规则：最小字符长度为8，最大为15，条目个数限制：[1，500] */\n    ]\n  }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6565,7 +6526,50 @@
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_2.shtml\n   接口说明：商户可以创建满额送活动，用户支付后送全场券，提升交易额。 */\n{\n  \"activity_base_info\": {\n    \"activity_name\": \"良品铺子回馈活动\", ///活动名称\n    \"activity_second_title\": \"海飞丝的券\", //活动副标题\n    \"merchant_logo_url\": \"https://tool.oschina.net/regex.jpg\", ///商户logo，送出优惠券时展示， 仅支持通过《图片上传API》接口获取的图片URL地址。\n    \"background_color\": \"COLOR010\",///代金券的背景颜色，可设置10种颜色，颜色取值请参见色卡图，默认为微信支付绿色， 颜色取值为颜色图中的颜色名称。\n    \"begin_time\": \"2015-05-20T13:29:35+08:00\",///活动开始时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"end_time\": \"2015-05-20T13:29:35+08:00\",///1、活动结束时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    \"out_request_no\": \"100002322019090134234sfdf\", ///商户创建批次凭据号（格式：商户id+日期+流水号），商户侧需保持唯一性，可包含英文字母，数字，｜，_，*，-等内容，不允许出现其他不合法符号。\n    \"delivery_purpose\": \"OFF_LINE_PAY\", ///投放目的：枚举值：OFF_LINE_PAY：拉用户回店消费 JUMP_MINI_APP：引导用户前往小程序消费\n    \"mini_programs_appid\": \"{{appid}}\", ///投放目的为JUMP_MINI_APP时必填\n    \"mini_programs_path\": \"/path/index/index\" ///如果传入此参数，则跳转至商家小程序；反之则跳转至券详情页面。\n  },\n  \"award_send_rule\": {\n    \"transaction_amount_minimum\": 100, ///消费金额门槛，单位：分。 注：该字段金额指订单金额\n    \"send_content\": \"SINGLE_COUPON\", ///发放内容，可选单张券或礼包，选礼包时奖品限定3-5个。枚举值：SINGLE_COUPON：单张券 GIFT_PACKAGE：礼包\n    \"award_type\": \"BUSIFAVOR\", ///奖品类型，暂时只支持商家券。枚举值： BUSIFAVOR：商家券\n    \"award_list\": [\n      {\n        \"stock_id\": \"98065001\",///券批次ID，暂时只支持商家券\n        \"original_image_url\": \"https://tool.oschina.net/regex.jpg\", ///奖品大图，图片建议尺寸：678像素*232像素，支持JPG、PNG格式； 仅支持通过《图片上传API》接口获取的图片URL地址。\n        \"thumbnail_url\": \"https://tool.oschina.net/regex.jpg\"///奖品小图，图片建议尺寸：120像素*120像素，支持JPG、PNG格式；当选多张券时必填， 仅支持通过《图片上传API》接口获取的图片URL地址。\n      }\n    ],\n    \"merchant_option\": \"MANUAL_INPUT_MERCHANT\", ///曝光商户号选取规则，支持选择在用券商户号和手动输入曝光商户号两种规则，当选择手动输入曝光商户号时，曝光商户号必填（商家券只支持手动输入）。枚举值：IN_SEVICE_COUPON_MERCHANT：在用券商户号 MANUAL_INPUT_MERCHANT：手动输入曝光商户号\n    \"merchant_id_list\": [\n      \"10000022\",\n      \"10000023\"\n      /* 曝光商户号，列表。当merchant_option为MANUAL_INPUT_MERCHANT时，该字段必填。曝光商户号需与投放的商家券归属商户号一致或有同品牌关系。\n      特殊规则：最小字符长度为8，最大为15，条目个数限制：[1，500] */\n    ]\n  }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/unique-threshold-activity",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"unique-threshold-activity"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"activity_id\": \"10028001\",///支付有礼活动id\n  \"create_time\": \"2015-05-20T13:29:35+08:00\" ///创建活动的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
 						},
 						{
 							"name": "查询活动详情接口",
@@ -6573,7 +6577,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要查询的支付有礼活动ID}}",
 									"host": [
 										"{{server_url}}"
 									],
@@ -6582,11 +6586,46 @@
 										"marketing",
 										"paygiftactivity",
 										"activities",
-										"10028001"
+										"{{此处替换为要查询的支付有礼活动ID}}"
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要查询的支付有礼活动ID}}",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities",
+												"{{此处替换为要查询的支付有礼活动ID}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 返回参数说明看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_4.shtml */\n{\n  \"activity_id\": \"10028001\",\n  \"activity_type\": \"FULL_SEND_ACT_TYPE\",\n  \"activity_base_info\": {\n    \"activity_name\": \"良品铺子回馈活动\",\n    \"activity_second_title\": \"海飞丝的券\",\n    \"merchant_logo_url\": \"https://tool.oschina.net/regex.jpg\",\n    \"background_color\": \"COLOR020\",\n    \"begin_time\": \"2015-05-20T13:29:35+08:00\",\n    \"end_time\": \"2015-05-20T13:29:35+08:00\",\n    \"available_periods\": {\n      \"available_time\": [\n        {\n          \"begin_time\": \"2015-05-20T00:00:00+08:00\",\n          \"end_time\": \"2015-05-20T23:59:59+08:00\"\n        }\n      ],\n      \"available_day_time\": [\n        {\n          \"begin_day_time\": \"110000\",\n          \"end_day_time\": \"135959\"\n        }\n      ]\n    },\n    \"out_request_no\": \"100002322019090134234sfdf\",\n    \"delivery_purpose\": \"OFF_LINE_PAY\",\n    \"mini_programs_appid\": \"wx23232232323\",\n    \"mini_programs_path\": \"/path/index/index\"\n  },\n  \"award_send_rule\": {\n    \"full_send_rule\": {\n      \"transaction_amount_minimum\": 100,\n      \"send_content\": \"SINGLE_COUPON\",\n      \"award_type\": \"BUSIFAVOR\",\n      \"award_list\": [\n        {\n          \"stock_id\": \"98065001\",\n          \"original_image_url\": \"https://tool.oschina.net/regex.jpg\",\n          \"thumbnail_url\": \"https://tool.oschina.net/regex.jpg\"\n        }\n      ],\n      \"merchant_option\": \"MANUAL_INPUT_MERCHANT\"\n    }\n  },\n  \"advanced_setting\": {\n    \"delivery_user_category\": \"DELIVERY_MEMBER_PERSON\",\n    \"merchant_member_appid\": \"34567890\",\n    \"goods_tags\": [\n      \"xxx\",\n      \"yyy\"\n    ]\n  },\n  \"activity_status\": \"CREATE_ACT_STATUS\",\n  \"creator_merchant_id\": \"10000022\",\n  \"belong_merchant_id\": \"10000022\",\n  \"pause_time\": \"2015-05-20T13:29:35+08:00\",\n  \"recovery_time\": \"2015-05-20T13:29:35+08:00\",\n  \"create_time\": \"2015-05-20T13:29:35+08:00\",\n  \"update_time\": \"2015-05-20T13:29:35+08:00\"\n} "
+								}
+							]
 						},
 						{
 							"name": "查询活动发券商户号",
@@ -6594,7 +6633,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001/merchants?offset=1&limit=20",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要查询的支付有礼活动ID}}/merchants?offset=0&limit=20",
 									"host": [
 										"{{server_url}}"
 									],
@@ -6603,22 +6642,72 @@
 										"marketing",
 										"paygiftactivity",
 										"activities",
-										"10028001",
+										"{{此处替换为要查询的支付有礼活动ID}}",
 										"merchants"
 									],
 									"query": [
 										{
 											"key": "offset",
-											"value": "1"
+											"value": "0",
+											"description": "分页页码，页面从0开始"
 										},
 										{
 											"key": "limit",
-											"value": "20"
+											"value": "20",
+											"description": "限制分页最大数据条目。"
 										}
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要查询的支付有礼活动ID}}/merchants?offset=0&limit=20",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities",
+												"{{此处替换为要查询的支付有礼活动ID}}",
+												"merchants"
+											],
+											"query": [
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "分页页码，页面从0开始"
+												},
+												{
+													"key": "limit",
+													"value": "20",
+													"description": "限制分页最大数据条目。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"data\": [\n    {\n      \"mchid\": \"6002309\", ///商户号\n      \"merchant_name\": \"良品铺子\", ///商户名称\n      \"create_time\": \"2015-05-20T13:29:35+08:00\", ///创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n      \"update_time\": \"2015-05-20T13:29:35+08:00\" ///更新时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    }\n  ],\n  \"total_count\": 30, ///商户数量\n  \"offset\": 4, ///分页页码\n  \"limit\": 20, ///限制分页最大数据条目。\n  \"activity_id\": \"126002309\" ///支付有礼活动ID\n}"
+								}
+							]
 						},
 						{
 							"name": "查询活动指定商品列表",
@@ -6626,7 +6715,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001/goods?offset=1&limit=20",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要查询的支付有礼活动ID}}/goods?offset=0&limit=20",
 									"host": [
 										"{{server_url}}"
 									],
@@ -6635,22 +6724,72 @@
 										"marketing",
 										"paygiftactivity",
 										"activities",
-										"10028001",
+										"{{此处替换为要查询的支付有礼活动ID}}",
 										"goods"
 									],
 									"query": [
 										{
 											"key": "offset",
-											"value": "1"
+											"value": "0",
+											"description": "分页页码"
 										},
 										{
 											"key": "limit",
-											"value": "20"
+											"value": "20",
+											"description": "限制分页最大数据条目。"
 										}
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要查询的支付有礼活动ID}}/goods?offset=0&limit=20",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities",
+												"{{此处替换为要查询的支付有礼活动ID}}",
+												"goods"
+											],
+											"query": [
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "分页页码"
+												},
+												{
+													"key": "limit",
+													"value": "20",
+													"description": "限制分页最大数据条目。"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"data\": [\n    {\n      \"goods_id\": \"0345678\",///指定商品（商户侧sku）\n      \"create_time\": \"2015-05-20T13:29:35+08:00\",///创建时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n      \"update_time\": \"2015-05-20T13:29:35+08:00\"///更新时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n    }\n  ],\n  \"total_count\": 24,///商户数量\n  \"offset\": 4,///分页页码\n  \"limit\": 20,///限制分页最大数据条目。\n  \"activity_id\": \"10028001\" ///支付有礼活动id\n}"
+								}
+							]
 						},
 						{
 							"name": "终止活动",
@@ -6658,7 +6797,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/10028001/terminate",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要终止的支付有礼活动id}}/terminate",
 									"host": [
 										"{{server_url}}"
 									],
@@ -6667,12 +6806,48 @@
 										"marketing",
 										"paygiftactivity",
 										"activities",
-										"10028001",
+										"{{此处替换为要终止的支付有礼活动id}}",
 										"terminate"
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要终止的支付有礼活动id}}/terminate",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities",
+												"{{此处替换为要终止的支付有礼活动id}}",
+												"terminate"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"terminate_time\": \"2015-05-20T13:29:35+08:00\",///终止生效时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"activity_id\": \"10028001\"///终止的支付有礼活动ID\n}"
+								}
+							]
 						},
 						{
 							"name": "新增活动发券商户号",
@@ -6681,7 +6856,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ],\n  \"add_request_no\" : \"100002322019090134234sfdf\"\n}",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_8.shtml\n   接口说明：商户创建活动后，可以通过该接口增加支付有礼的发券商户号，用于管理活动。 */\n{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ], ///新增到活动中的发券商户号列表，特殊规则：最小字符长度为8，最大为15，条目个数限制：[1，500]\n  \"add_request_no\" : \"100002322019090134234sfdf\"商户添加发券商户号的凭据号，商户侧需保持唯一性\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6689,7 +6864,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/add",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要增加的支付有礼活动ID}}/merchants/add",
 									"host": [
 										"{{server_url}}"
 									],
@@ -6698,13 +6873,59 @@
 										"marketing",
 										"paygiftactivity",
 										"activities",
-										"{activity_id}",
+										"{{此处替换为要增加的支付有礼活动ID}}",
 										"merchants",
 										"add"
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_8.shtml\n   接口说明：商户创建活动后，可以通过该接口增加支付有礼的发券商户号，用于管理活动。 */\n{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ], ///新增到活动中的发券商户号列表，特殊规则：最小字符长度为8，最大为15，条目个数限制：[1，500]\n  \"add_request_no\" : \"100002322019090134234sfdf\"商户添加发券商户号的凭据号，商户侧需保持唯一性\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要增加的支付有礼活动ID}}/merchants/add",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities",
+												"{{此处替换为要增加的支付有礼活动ID}}",
+												"merchants",
+												"add"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"activity_id\" : \"1001234567\",///支付有礼活动ID\n  \"invalid_merchant_id_list\" : [ {\n    \"mchid\" : \"1001234567\",///未通过规则校验的发券商户号\n    \"invalid_reason\" : \"商户与活动创建方不具备父子关系\" ///活动参与商户校验失败的原因\n  }, {\n    \"mchid\" : \"1001234567\", ///未通过规则校验的发券商户号\n    \"invalid_reason\" : \"商户与活动创建方不具备父子关系\"///活动参与商户校验失败的原因\n  } ],\n  \"add_time\" : \"2015-05-20T13:29:35+08:00\" ///成功添加发券商户号的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n}"
+								}
+							]
 						},
 						{
 							"name": "获取支付有礼活动列表",
@@ -6725,20 +6946,74 @@
 									"query": [
 										{
 											"key": "offset",
-											"value": "0"
+											"value": "0",
+											"description": "分页页码，页面从0开始"
 										},
 										{
 											"key": "limit",
-											"value": "10"
+											"value": "10",
+											"description": "分页大小，特殊规则：最大取值为100，最小为1"
 										},
 										{
 											"key": "activity_status",
-											"value": "ONGOING_ACT_STATUS"
+											"value": "ONGOING_ACT_STATUS",
+											"description": "活动状态，枚举值：\nACT_STATUS_UNKNOWN：状态未知\nCREATE_ACT_STATUS：已创建\nONGOING_ACT_STATUS：运行中\nTERMINATE_ACT_STATUS：已终止\nSTOP_ACT_STATUS：已暂停\nOVER_TIME_ACT_STATUS：已过期\nCREATE_ACT_FAILED：创建活动失败"
 										}
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities?offset=0&limit=10&activity_status=ONGOING_ACT_STATUS",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities"
+											],
+											"query": [
+												{
+													"key": "offset",
+													"value": "0",
+													"description": "分页页码，页面从0开始"
+												},
+												{
+													"key": "limit",
+													"value": "10",
+													"description": "分页大小，特殊规则：最大取值为100，最小为1"
+												},
+												{
+													"key": "activity_status",
+													"value": "ONGOING_ACT_STATUS",
+													"description": "活动状态，枚举值：\nACT_STATUS_UNKNOWN：状态未知\nCREATE_ACT_STATUS：已创建\nONGOING_ACT_STATUS：运行中\nTERMINATE_ACT_STATUS：已终止\nSTOP_ACT_STATUS：已暂停\nOVER_TIME_ACT_STATUS：已过期\nCREATE_ACT_FAILED：创建活动失败"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "/* 参数说明请看文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_9.shtml */\n{\n    \"data\": [\n        {\n            \"activity_base_info\": {\n                \"activity_name\": \"满减活动\",\n                \"activity_second_title\": \"满减活动副\",\n                \"background_color\": \"COLOR010\",\n                \"begin_time\": \"2020-06-02T10:00:00+08:00\",\n                \"delivery_purpose\": \"JUMP_MINI_APP\",\n                \"end_time\": \"2020-06-02T23:29:35+08:00\",\n                \"merchant_logo_url\": \"https://wxpaylogo.qpic.cn/wxpaylogo/PiajxSqBRaEI1qUibGfkJ4N3JCS5EmAH5xVmo9iam8msMM0XopTYGDGOQ/0\",\n                \"mini_programs_appid\": \"wxab8acb865bb1637e\",\n                \"mini_programs_path\": \"/path/index/index\",\n                \"out_request_no\": \"100002322020-0602-1047-99\"\n            },\n            \"activity_id\": \"20406354\",\n            \"activity_status\": \"OVER_TIME_ACT_STATUS\",\n            \"activity_type\": \"FULL_SEND_ACT_TYPE\",\n            \"advanced_setting\": {\n                \"delivery_user_category\": \"DELIVERY_ALL_PERSON\",\n                \"goods_tags\": [\n                    \"0602-1047-99\"\n                ]\n            },\n            \"award_send_rule\": {\n                \"full_send_rule\": {\n                    \"award_list\": [\n                        {\n                            \"original_image_url\": \"https://wxpaylogo.qpic.cn/wxpaylogo/PiajxSqBRaEI1qUibGfkJ4N3JCS5EmAH5xVmo9iam8msMM0XopTYGDGOQ/0\",\n                            \"stock_id\": \"1263540000000013\",\n                            \"thumbnail_url\": \"https://wxpaylogo.qpic.cn/wxpaylogo/PiajxSqBRaEI1qUibGfkJ4N3JCS5EmAH5xVmo9iam8msMM0XopTYGDGOQ/0\"\n                        }\n                    ],\n                    \"award_type\": \"BUSIFAVOR\",\n                    \"merchant_id_list\": [],\n                    \"merchant_option\": \"MANUAL_INPUT_MERCHANT\",\n                    \"send_content\": \"SINGLE_COUPON\",\n                    \"transaction_amount_minimum\": 1\n                }\n            },\n            \"belong_merchant_id\": \"1900009251\",\n            \"create_time\": \"2020-06-02T10:47:26+08:00\",\n            \"creator_merchant_id\": \"1900009251\",\n            \"update_time\": \"2020-06-05T10:26:08+08:00\"\n        },\n        {\n            \"activity_base_info\": {\n                \"activity_name\": \"满减活动\",\n                \"activity_second_title\": \"满减活动副\",\n                \"background_color\": \"COLOR010\",\n                \"begin_time\": \"2020-06-01T10:00:00+08:00\",\n                \"delivery_purpose\": \"JUMP_MINI_APP\",\n                \"end_time\": \"2020-06-01T23:29:35+08:00\",\n                \"merchant_logo_url\": \"https://wxpaylogo.qpic.cn/wxpaylogo/PiajxSqBRaEI1qUibGfkJ4N3JCS5EmAH5xVmo9iam8msMM0XopTYGDGOQ/0\",\n                \"mini_programs_appid\": \"wxab8acb865bb1637e\",\n                \"mini_programs_path\": \"/path/index/index\",\n                \"out_request_no\": \"100002322020-0601-1147-99\"\n            },\n            \"activity_id\": \"10406354\",\n            \"activity_status\": \"OVER_TIME_ACT_STATUS\",\n            \"activity_type\": \"FULL_SEND_ACT_TYPE\",\n            \"advanced_setting\": {\n                \"delivery_user_category\": \"DELIVERY_ALL_PERSON\",\n                \"goods_tags\": [\n                    \"0601-1147-99\"\n                ]\n            },\n            \"award_send_rule\": {\n                \"full_send_rule\": {\n                    \"award_list\": [\n                        {\n                            \"original_image_url\": \"https://wxpaylogo.qpic.cn/wxpaylogo/PiajxSqBRaEI1qUibGfkJ4N3JCS5EmAH5xVmo9iam8msMM0XopTYGDGOQ/0\",\n                            \"stock_id\": \"1263540000000012\",\n                            \"thumbnail_url\": \"https://wxpaylogo.qpic.cn/wxpaylogo/PiajxSqBRaEI1qUibGfkJ4N3JCS5EmAH5xVmo9iam8msMM0XopTYGDGOQ/0\"\n                        }\n                    ],\n                    \"award_type\": \"BUSIFAVOR\",\n                    \"merchant_id_list\": [],\n                    \"merchant_option\": \"MANUAL_INPUT_MERCHANT\",\n                    \"send_content\": \"SINGLE_COUPON\",\n                    \"transaction_amount_minimum\": 1\n                }\n            },\n            \"belong_merchant_id\": \"1900009251\",\n            \"create_time\": \"2020-06-01T11:49:06+08:00\",\n            \"creator_merchant_id\": \"1900009251\",\n            \"update_time\": \"2020-06-05T10:26:08+08:00\"\n        }\n    ],\n    \"total_count\": 2,\n    \"offset\": 1,\n    \"limit\": 20\n}"
+								}
+							]
 						},
 						{
 							"name": "删除活动发券商户号",
@@ -6747,7 +7022,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ],\n  \"delete_request_no\" : \"100002322019090134234sfdf\"\n}\n",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_10.shtml\n   接口说明：商户创建活动后，可以通过该接口删除支付有礼的发券商户号，用于管理活动。 */\n{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ], ///从活动已有的发券商户号中移除的商户号列表 特殊规则：最小字符长度为8，最大为15。 条目个数限制：[1, 500]\n  \"delete_request_no\" : \"100002322019090134234sfdf\"\n}\n",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6755,7 +7030,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{activity_id}/merchants/delete",
+									"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要修改的支付有礼活动ID}}/merchants/delete",
 									"host": [
 										"{{server_url}}"
 									],
@@ -6764,13 +7039,57 @@
 										"marketing",
 										"paygiftactivity",
 										"activities",
-										"{activity_id}",
+										"{{此处替换为要修改的支付有礼活动ID}}",
 										"merchants",
 										"delete"
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "200_OK",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_7_10.shtml\n   接口说明：商户创建活动后，可以通过该接口删除支付有礼的发券商户号，用于管理活动。 */\n{\n  \"merchant_id_list\" : [ \"100123456\", \"100123457\" ], ///从活动已有的发券商户号中移除的商户号列表 特殊规则：最小字符长度为8，最大为15。 条目个数限制：[1, 500]\n  \"delete_request_no\" : \"100002322019090134234sfdf\"\n}\n",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{server_url}}/v3/marketing/paygiftactivity/activities/{{此处替换为要修改的支付有礼活动ID}}/merchants/delete",
+											"host": [
+												"{{server_url}}"
+											],
+											"path": [
+												"v3",
+												"marketing",
+												"paygiftactivity",
+												"activities",
+												"{{此处替换为要修改的支付有礼活动ID}}",
+												"merchants",
+												"delete"
+											]
+										}
+									},
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"name": "Content-Type",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\n  \"delete_time\" : \"2015-05-20T13:29:35+08:00\", ///成功删除发券商户号的时间，遵循rfc3339标准格式，格式为yyyy-MM-DDTHH:mm:ss+TIMEZONE\n  \"activity_id\" : \"126002309\" ///支付有礼活动ID\n}"
+								}
+							]
 						}
 					]
 				}
@@ -7461,14 +7780,9 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "https://api.mch.weixin.qq.com/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
-									"protocol": "https",
+									"raw": "{{server_url}}/v3/billdownload/file?token=6XIv5TUPto7pByrTQKhd6kwvyKLG2uY2wMMR8cNXqaA_Cv_isgaUtBzp4QtiozLO",
 									"host": [
-										"api",
-										"mch",
-										"weixin",
-										"qq",
-										"com"
+										"{{server_url}}"
 									],
 									"path": [
 										"v3",
@@ -7567,7 +7881,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{server_url}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?&transaction_id=4208450740201411110007820472",
+									"raw": "{{server_url}}/v3/profitsharing/orders/{{此处替换为要查询的商家分账单号}}?transaction_id=4208450740201411110007820472",
 									"host": [
 										"{{server_url}}"
 									],
@@ -7578,10 +7892,6 @@
 										"{{此处替换为要查询的商家分账单号}}"
 									],
 									"query": [
-										{
-											"key": null,
-											"value": null
-										},
 										{
 											"key": "transaction_id",
 											"value": "4208450740201411110007820472",
@@ -7726,7 +8036,7 @@
 									"query": [
 										{
 											"key": null,
-											"value": null
+											"value": ""
 										},
 										{
 											"key": "out_order_no",
@@ -7916,10 +8226,17 @@
 							},
 							"request": {
 								"method": "GET",
-								"header": [],
+								"header": [
+									{
+										"key": "Wechatpay-Serial",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
 								"body": {
 									"mode": "raw",
-									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_8.shtml\n   接口说明：商户发起添加分账接收方请求，建立分账接收方列表。后续可通过发起分账请求，将分账方商户结算后的资金，分到该分账接收方\n   注意：商户需确保向微信支付传输用户身份信息和账号标识信息做一致性校验已合法征得用户授权 */\n{\n  \"appid\": \"wx8888888888888888\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n  \"relation_type\": \"CUSTOM\",\n  /*商户与接收方的关系。 本字段值为枚举：STORE：门店 STAFF：员工 STORE_OWNER：店主 PARTNER：合作伙伴 HEADQUARTER：总部 BRAND：品牌方 DISTRIBUTOR：分销商\n    USER：用户 SUPPLIER： 供应商 CUSTOM：自定义 */\n  \"custom_relation\": \"代理商\"///商户与接收方具体的关系，本字段最多10个字。当字段relation_type的值为CUSTOM时，本字段必填;当字段relation_type的值不为CUSTOM时，本字段无需填写。\n}",
+									"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_8.shtml\n   接口说明：商户发起添加分账接收方请求，建立分账接收方列表。后续可通过发起分账请求，将分账方商户结算后的资金，分到该分账接收方\n   注意：商户需确保向微信支付传输用户身份信息和账号标识信息做一致性校验已合法征得用户授权 */\n{\n  \"appid\": \"wx8888888888888888\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n  \"relation_type\": \"CUSTOM\",\n  /*商户与接收方的关系。 本字段值为枚举：STORE：门店 STAFF：员工 STORE_OWNER：店主 PARTNER：合作伙伴 HEADQUARTER：总部 BRAND：品牌方 DISTRIBUTOR：分销商\n    USER：用户 SUPPLIER： 供应商 CUSTOM：自定义 */\n  \"name\":\"hu89ohu89ohu89o\",\n  /*分账接收方类型是MERCHANT_ID时，是商户全称（必传），当商户是小微商户或个体户时，是开户人姓名 分账接收方类型是PERSONAL_OPENID时，是个人姓名（选传，传则校验） 分账接收方类型是PERSONAL_SUB_OPENID时，是个人姓名（选传，传则校验）1、此字段需要加密，加密方法详见：敏感信息加密说明 2、使用微信支付平台证书中的公钥\n3、使用RSAES-OAEP算法进行加密 4、将请求中HTTP头部的Wechatpay-Serial设置为证书序列号 */\n  \"custom_relation\": \"代理商\"///商户与接收方具体的关系，本字段最多10个字。当字段relation_type的值为CUSTOM时，本字段必填;当字段relation_type的值不为CUSTOM时，本字段无需填写。\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -7945,15 +8262,6 @@
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_8.shtml\n   接口说明：商户发起添加分账接收方请求，建立分账接收方列表。后续可通过发起分账请求，将分账方商户结算后的资金，分到该分账接收方\n   注意：商户需确保向微信支付传输用户身份信息和账号标识信息做一致性校验已合法征得用户授权 */\n{\n  \"appid\": \"wx8888888888888888\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"{{此处替换为分账接收方商户号}}\",///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n  \"relation_type\": \"CUSTOM\",\n  /*商户与接收方的关系。 本字段值为枚举：STORE：门店 STAFF：员工 STORE_OWNER：店主 PARTNER：合作伙伴 HEADQUARTER：总部 BRAND：品牌方 DISTRIBUTOR：分销商\n    USER：用户 SUPPLIER： 供应商 CUSTOM：自定义 */\n  \"custom_relation\": \"代理商\"///商户与接收方具体的关系，本字段最多10个字。当字段relation_type的值为CUSTOM时，本字段必填;当字段relation_type的值不为CUSTOM时，本字段无需填写。\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
 										"url": {
 											"raw": "{{server_url}}/v3/profitsharing/receivers/add",
 											"host": [
@@ -7986,11 +8294,8 @@
 						},
 						{
 							"name": "删除分账接收方",
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
@@ -8020,15 +8325,6 @@
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "/* 接口地址：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_9.shtml\n   接口说明：商户发起删除分账接收方请求。删除后，不支持将分账方商户结算后的资金，分到该分账接收方 */\n{\n  \"appid\": \"{{appid}}\",///商户号绑定的APPID\n  \"type\": \"MERCHANT_ID\",///分账接收方类型\t1、MERCHANT_ID：商户号 2、PERSONAL_OPENID：个人微信openid，需要和appid一一对应\n  \"account\": \"1900000109\"///分账接收方账号：1、类型是MERCHANT_ID时，是商户号（mch_id或者sub_mch_id） 2、类型是PERSONAL_OPENID时，是个人微信用户的openid\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
 										"url": {
 											"raw": "{{server_url}}/v3/profitsharing/receivers/delete",
 											"host": [
@@ -8602,10 +8898,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -8668,10 +8964,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -8734,10 +9030,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						},
@@ -8800,10 +9096,10 @@
 									},
 									"status": "No Content",
 									"code": 204,
-									"_postman_previewlanguage": null,
-									"header": null,
+									"_postman_previewlanguage": "Text",
+									"header": [],
 									"cookie": [],
-									"body": null
+									"body": ""
 								}
 							]
 						}

--- a/wechatpay-apiv3.postman_collection.json
+++ b/wechatpay-apiv3.postman_collection.json
@@ -8257,7 +8257,7 @@
 								{
 									"name": "200_OK",
 									"originalRequest": {
-										"method": "GET",
+										"method": "POST",
 										"header": [],
 										"url": {
 											"raw": "{{server_url}}/v3/profitsharing/receivers/add",
@@ -8320,7 +8320,7 @@
 								{
 									"name": "200_OK",
 									"originalRequest": {
-										"method": "GET",
+										"method": "POST",
 										"header": [],
 										"url": {
 											"raw": "{{server_url}}/v3/profitsharing/receivers/delete",


### PR DESCRIPTION
补充了微信支付普通商户已知公开接口，每个接口请求预置了请求参数示例与请求成功返回的参数示例,修改原脚本变量为常用叫法，无其他修改部分： merchantId->mchid
merchantSerialNo->merchant_serial_no
merchantPrivateKey->apiclient_key.pem
预置请求参数需要配置全局变量
endpoint	必填	微信支付接口域名	固定值：https://api.mch.weixin.qq.com
 appid	选填	用于微信支付接口请求中的APPID	如不配置全局变量，请求时需要将参数中的变量替换为实际APPID值，填写APPID需要与填写的mchid有绑定关系
 openid	选填	用于微信支付接口请求中的openid	如不配置全局变量，请求时需要将参数中的变量openid替换为实际openid值